### PR TITLE
Update clang for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
           packages:
             - g++-5
             - clang-3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,17 +38,16 @@ matrix:
         - make
         - cd -
 
-    - env: CC="clang-3.9" CXX="clang++-3.9"
+    - env: CC="clang-3.8" CXX="clang++-3.8"
       os: linux
       sudo: false
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
           packages:
             - g++-5
-            - clang-3.9
+            - clang-3.8
             - scons
             - libgtest-dev
             - subversion
@@ -63,14 +62,14 @@ matrix:
        # install openmp
        - svn co http://llvm.org/svn/llvm-project/openmp/trunk ~/openmp
        - cd ~/openmp/runtime/
-       - cmake -D CMAKE_INSTALL_PREFIX:PATH=./ ./ -DCMAKE_C_COMPILER=clang-3.9 -DCMAKE_CXX_COMPILER=clang++-3.9
+       - cmake -D CMAKE_INSTALL_PREFIX:PATH=./ ./ -DCMAKE_C_COMPILER=clang-3.8 -DCMAKE_CXX_COMPILER=clang++-3.8
        - make
        - export OPENMP_LIB=$(pwd)/src/
        - export OPENMP_INCLUDE=$(pwd)/src/
        - export LD_LIBRARY_PATH=$OPENMP_LIB:$LD_LIBRARY_PATH
        - cd -
 
-    - env: CC=clang-3.9 CXX=clang++-3.9
+    - env: CC=clang-3.8 CXX=clang++-3.8
       os: osx
       sudo: false
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,14 +70,14 @@ matrix:
        - export LD_LIBRARY_PATH=$OPENMP_LIB:$LD_LIBRARY_PATH
        - cd -
 
-    - env: CC=clang-3.8 CXX=clang++-3.8
+    - env: CC=clang-3.7 CXX=clang++-3.7
       os: osx
       sudo: false
       before_install:
         - brew update
         - brew tap homebrew/versions
         - brew install scons
-        - brew install llvm@3.8
+        - brew install llvm37
       install:
         # install gtest
         - git clone https://github.com/google/googletest.git ~/gtest/

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         - brew update
         - brew tap homebrew/versions
         - brew install scons
-        - brew install llvm37
+        - brew install llvm@3.8
       install:
         # install gtest
         - git clone https://github.com/google/googletest.git ~/gtest/

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         - make
         - cd -
 
-    - env: CC="clang-3.7" CXX="clang++-3.7"
+    - env: CC="clang-3.9" CXX="clang++-3.9"
       os: linux
       sudo: false
       addons:
@@ -48,7 +48,7 @@ matrix:
             - llvm-toolchain-precise-3.7
           packages:
             - g++-5
-            - clang-3.7
+            - clang-3.9
             - scons
             - libgtest-dev
             - subversion
@@ -63,14 +63,14 @@ matrix:
        # install openmp
        - svn co http://llvm.org/svn/llvm-project/openmp/trunk ~/openmp
        - cd ~/openmp/runtime/
-       - cmake -D CMAKE_INSTALL_PREFIX:PATH=./ ./ -DCMAKE_C_COMPILER=clang-3.7 -DCMAKE_CXX_COMPILER=clang++-3.7
+       - cmake -D CMAKE_INSTALL_PREFIX:PATH=./ ./ -DCMAKE_C_COMPILER=clang-3.9 -DCMAKE_CXX_COMPILER=clang++-3.9
        - make
        - export OPENMP_LIB=$(pwd)/src/
        - export OPENMP_INCLUDE=$(pwd)/src/
        - export LD_LIBRARY_PATH=$OPENMP_LIB:$LD_LIBRARY_PATH
        - cd -
 
-    - env: CC=clang-3.7 CXX=clang++-3.7
+    - env: CC=clang-3.9 CXX=clang++-3.9
       os: osx
       sudo: false
       before_install:


### PR DESCRIPTION
Will also update clang for macOS in a later PR. There are some issues with macOS since vanilla clang-3.8 has build-in OpenMP support which uses the Intel OpenMP library (libomp) instead of the GCC implementation (libgomp) which would be used otherwise. This doesn't work since `#include <parallel/algorithm>` for example will fail since it is apparently not supported in the Intel OpenMP implementation. That is at least my conclusion after some testing. Let me know if you have thoughts on that.