### PR TITLE
Update setup.py to cythonize in a Git environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ do_cythonize = False
 # depending on the role in which the setup script is called, it will be determined if _NetworKit.pyx will be cythonized.
 build_ext_cmd = None
 # the `build_ext` command depends on the role of the setup script
-if not os.path.exists(".hg") and os.path.isfile("networkit/_NetworKit.cpp"):
+if not os.path.exists(".git") and not os.path.exists(".hg") and os.path.isfile("networkit/_NetworKit.cpp"):
 	#print("using pre-cythonized _NetworKit.cpp")
 	# we assume, were not in the repository, but installing networkit from a zip or via pip
 	if os.path.isfile("MANIFEST.in"):


### PR DESCRIPTION
The setup script currently only checks if the Mercurial directory (.hg) is present to determine whether to use the pre-cythonized _NetworKit.cpp. Therefore, the Cython wrapper is never re-built if you checked out NetworKit in Git.