### PR TITLE
Closeness fixes

### DIFF
--- a/networkit/cpp/centrality/TopCloseness.cpp
+++ b/networkit/cpp/centrality/TopCloseness.cpp
@@ -9,6 +9,7 @@
 #include <queue>
 #include <memory>
 #include <omp.h>
+#include <cstdlib>
 
 #include "TopCloseness.h"
 #include "../components/ConnectedComponents.h"
@@ -288,10 +289,10 @@ void TopCloseness::BFSbound(node x, std::vector<double> &S2, count *visEdges) {
     // we compute the bound for the first level
     count closeNodes = 0, farNodes = 0;
     for (count j = 0; j <= nLevs; j++) {
-        if (abs((long long)j-1LL)<=1)  {
+        if (std::abs((long long)j-1LL)<=1)  {
             closeNodes += nodesPerLev[j];
         } else {
-            farNodes += nodesPerLev[j]*abs(1LL-(long long)j);
+            farNodes += nodesPerLev[j]*std::abs(1LL-(long long)j);
         }
     }
 

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -878,6 +878,7 @@ TEST_F(CentralityGTest, testTopClosenessDirected) {
 }
 
 TEST_F(CentralityGTest, testTopClosenessUndirected) {
+    Aux::Random::setSeed(42, true);
     count size = 400;
     count k = 10;
     Graph G1 = DorogovtsevMendesGenerator(size).generate();

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -853,6 +853,7 @@ TEST_F(CentralityGTest, testSimplePermanence) {
 }
 
 TEST_F(CentralityGTest, testTopClosenessDirected) {
+    Aux::Random::setSeed(42, true);
     count size = 400;
     count k = 10;
     Graph G1 = DorogovtsevMendesGenerator(size).generate();

--- a/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
+++ b/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
@@ -657,6 +657,7 @@ TEST_F(QuadTreeGTest, tryTreeExport) {
 }
 
 TEST_F(QuadTreeGTest, testPolarEuclidQuery) {
+	Aux::Random::setSeed(42, true);
 	/**
 	 * setup of data structures and constants
 	 */


### PR DESCRIPTION
This contains a few fixes related to #6 and #14 but they don't fix the real problems. Further, a compiler warning is fixed and another seed is set in `QuadTreeGTest`.