### PR TITLE
GraphML: fix writing of empty attributes

### DIFF
--- a/networkit/GraphMLIO.py
+++ b/networkit/GraphMLIO.py
@@ -149,7 +149,9 @@ class GraphMLWriter:
 			attrKeys[(attType, attName)] = 'd{0}'.format(maxAttrKey)
 			maxAttrKey += 1
 			attrElement.set('attr.name', attName)
-			if isinstance(attData[0], bool):
+			if len(attData) == 0:
+				attrElement.set('attr.type', 'int')
+			elif isinstance(attData[0], bool):
 				attrElement.set('attr.type', 'boolean')
 				# special handling for boolean attributes: convert boolean into lowercase string
 				if attType == 'edge':


### PR DESCRIPTION
Now, every attribute without values is written as integer attribute. An example is when your code wants to export edge attributes for a graph without edges.