### PR TITLE
GraphBuilder: enable some parallelism only for large graphs

### DIFF
--- a/networkit/cpp/graph/GraphBuilder.cpp
+++ b/networkit/cpp/graph/GraphBuilder.cpp
@@ -385,7 +385,7 @@ void GraphBuilder::toGraphSequential(Graph &G) {
 }
 
 void GraphBuilder::setDegrees(Graph& G) {
-	#pragma omp parallel for
+	#pragma omp parallel for if(n > (1<<20))
 	for (node v = 0; v < n; v++) {
 		G.outDeg[v] = G.outEdges[v].size();
 		if (G.isDirected()) {
@@ -396,7 +396,7 @@ void GraphBuilder::setDegrees(Graph& G) {
 
 count GraphBuilder::numberOfEdges(const Graph& G) {
 	count m = 0;
-	#pragma omp parallel for reduction(+:m)
+	#pragma omp parallel for reduction(+:m) if(n > (1<<20))
 	for (node v = 0; v < G.z; v++) {
 		m += G.degree(v);
 	}


### PR DESCRIPTION
This disables the parallelism in two loops in GraphBuilder for small graphs. Both of them are simple loops over the nodes with only sequential memory access. I actually doubt that parallelism is of any use here at all as this should be bound by RAM speeds. This change disables the parallelism at least for graphs with less than 1Mi nodes. For me, the parallelism lead to significant slow-downs when I created a large amount of small (less than 100 nodes) graphs.