### PR TITLE
LocalPartitionCoverage: fix for nodes with degree 0

### DIFF
--- a/networkit/cpp/centrality/LocalPartitionCoverage.cpp
+++ b/networkit/cpp/centrality/LocalPartitionCoverage.cpp
@@ -19,7 +19,10 @@ void NetworKit::LocalPartitionCoverage::run() {
 			if (P[u] == P[v]) scoreData[u] += ew;
 		});
 
-		scoreData[u] /= G.weightedDegree(u);
+		// Avoid division by 0 if u has no neighbors (then also scoreData[u] == 0).
+		if (scoreData[u] > 0) {
+			scoreData[u] /= G.weightedDegree(u);
+		}
 	});
 
 	hasRun = true;


### PR DESCRIPTION
This sets the local partition coverage for nodes with degree 0 to 0 (as they cover nothing). Of course one could also define it as 1, as all of their neighbors are within their own partition, it's just that I found 0 to be the more consistent solution.