### PR TITLE
EdgeListReader: skip empty lines consistently

### DIFF
--- a/networkit/cpp/io/EdgeListReader.cpp
+++ b/networkit/cpp/io/EdgeListReader.cpp
@@ -104,6 +104,7 @@ Graph EdgeListReader::readContinuous(const std::string& path) {
 	// split the line into start and end node. since the edges are sorted, the start node has the highest id of all nodes
 	i = 0; // count lines
 	while(std::getline(file,line)){
+		if (line.empty()) continue;
 		if(*line.rbegin() == '\r') line.pop_back();
 		++i;
 		if (line.compare(0, this->commentPrefix.length(), this->commentPrefix) == 0) {
@@ -201,6 +202,7 @@ Graph EdgeListReader::readNonContinuous(const std::string& path) {
 	// split the line into start and end node. since the edges are sorted, the start node has the highest id of all nodes
 	i = 0; // count lines
 	while(std::getline(file,line)){
+		if (line.empty()) continue;
 		if(*line.rbegin() == '\r') line.pop_back();
         ++i;
 		if (line.compare(0, this->commentPrefix.length(), this->commentPrefix) == 0) {


### PR DESCRIPTION
Before, empty lines were only skipped in the first pass but not in the second pass.