### PR TITLE
PartitionReader: allow to read partitions with none values

### DIFF
--- a/networkit/cpp/io/PartitionReader.cpp
+++ b/networkit/cpp/io/PartitionReader.cpp
@@ -29,7 +29,9 @@ Partition PartitionReader::read(std::string path) {
 		index c = std::atoi(line.c_str());
 		// extend the partition by one entry and store the cluster id
 		zeta[zeta.extend()] = c;
-		omega = std::max(c, omega);
+		if (c != none) {
+			omega = std::max(c, omega);
+		}
 	}
 
 	zeta.setUpperBound(omega+1);


### PR DESCRIPTION
This makes it possible to read partitions e.g. of graphs with deleted nodes.