### PR TITLE
SCD: use node type for seeds and add some const qualifiers

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -6620,7 +6620,7 @@ cdef class MatchingCoarsening(GraphCoarsening):
 cdef extern from "cpp/scd/PageRankNibble.h":
 	cdef cppclass _PageRankNibble "NetworKit::PageRankNibble":
 		_PageRankNibble(_Graph G, double alpha, double epsilon) except +
-		map[node, set[node]] run(set[unsigned int] seeds) except +
+		map[node, set[node]] run(set[node] seeds) except +
 
 cdef class PageRankNibble:
 	"""
@@ -6640,7 +6640,7 @@ cdef class PageRankNibble:
 		self._G = G
 		self._this = new _PageRankNibble(G._this, alpha, epsilon)
 
-	def run(self, set[unsigned int] seeds):
+	def run(self, set[node] seeds):
 		"""
 		Produces a cut around a given seed node.
 
@@ -6653,7 +6653,7 @@ cdef class PageRankNibble:
 cdef extern from "cpp/scd/GCE.h":
 	cdef cppclass _GCE "NetworKit::GCE":
 		_GCE(_Graph G, string quality) except +
-		map[node, set[node]] run(set[unsigned int] seeds) except +
+		map[node, set[node]] run(set[node] seeds) except +
 
 cdef class GCE:
 	"""
@@ -6670,7 +6670,7 @@ cdef class GCE:
 		self._G = G
 		self._this = new _GCE(G._this, stdstring(quality))
 
-	def run(self, set[unsigned int] seeds):
+	def run(self, set[node] seeds):
 		"""
 		Produces a cut around a given seed node.
 

--- a/networkit/cpp/scd/GCE.cpp
+++ b/networkit/cpp/scd/GCE.cpp
@@ -17,7 +17,7 @@ GCE::GCE(const Graph& G, std::string objective) : SelectiveCommunityDetector(G),
 	}
 }
 
-std::map<node, std::set<node> >  GCE::run(std::set<unsigned int>& seeds) {
+std::map<node, std::set<node> >  GCE::run(const std::set<node>& seeds) {
     std::map<node, std::set<node> > result;
     for (auto seed : seeds) {
         auto community = expandSeed(seed);

--- a/networkit/cpp/scd/GCE.h
+++ b/networkit/cpp/scd/GCE.h
@@ -29,7 +29,7 @@ public:
 	GCE(const Graph& G, std::string objective);
 
 
-	std::map<node, std::set<node> >  run(std::set<unsigned int>& seeds) override;
+	std::map<node, std::set<node> >  run(const std::set<node>& seeds) override;
 
 	/**
 	 * @param[in]	s	seed node

--- a/networkit/cpp/scd/PageRankNibble.cpp
+++ b/networkit/cpp/scd/PageRankNibble.cpp
@@ -14,7 +14,7 @@
 
 namespace NetworKit {
 
-PageRankNibble::PageRankNibble(Graph& g, double alpha, double epsilon): SelectiveCommunityDetector(g), alpha(alpha), epsilon(epsilon) {
+PageRankNibble::PageRankNibble(const Graph& g, double alpha, double epsilon): SelectiveCommunityDetector(g), alpha(alpha), epsilon(epsilon) {
 	if (g.isWeighted()) {
 		throw std::invalid_argument("Current implementation supports only unweighted graphs!");
 	}
@@ -99,7 +99,7 @@ std::set<node> PageRankNibble::expandSeed(node seed) {
 	return s;
 }
 
-std::map<node, std::set<node> >  PageRankNibble::run(std::set<unsigned int>& seeds) {
+std::map<node, std::set<node> >  PageRankNibble::run(const std::set<node>& seeds) {
     std::map<node, std::set<node> > result;
 	for (auto seed : seeds) {
 		auto community = expandSeed(seed);

--- a/networkit/cpp/scd/PageRankNibble.h
+++ b/networkit/cpp/scd/PageRankNibble.h
@@ -39,11 +39,11 @@ public:
 	 *        communities.
 	 * @param eps Tolerance threshold for approximation of PageRank vectors.
 	 */
-	PageRankNibble(Graph& g, double alpha, double epsilon);
+	PageRankNibble(const Graph& g, double alpha, double epsilon);
 
 	virtual ~PageRankNibble();
 
-	virtual std::map<node, std::set<node> >  run(std::set<unsigned int>& seeds);
+	virtual std::map<node, std::set<node> >  run(const std::set<node>& seeds) override;
 
 
 		/**

--- a/networkit/cpp/scd/SelectiveCommunityDetector.h
+++ b/networkit/cpp/scd/SelectiveCommunityDetector.h
@@ -25,10 +25,7 @@ public:
      * Detect communities for given seed nodes.
      * @return a mapping from seed node to community (as a set of nodes)
      */
-	virtual std::map<node, std::set<node> >  run(std::set<unsigned int>& seeds) = 0;
-
-	// FIXME: resolve Cython issue that does not allow a uint64_t as content type of a container as input
-
+	virtual std::map<node, std::set<node> >  run(const std::set<node>& seeds) = 0;
 
 protected:
 

--- a/networkit/cpp/scd/test/SelectiveCDGTest.cpp
+++ b/networkit/cpp/scd/test/SelectiveCDGTest.cpp
@@ -16,7 +16,7 @@ TEST_F(SCDGTest2, testPageRankNibble) {
 	Graph G = reader.read("input/hep-th.graph");
 	// parameters
 	node seed = 50;
-	std::set<unsigned int> seeds = {(unsigned int) seed};
+	std::set<node> seeds = {seed};
 	double alpha = 0.1; // loop (or teleport) probability, changed due to DGleich from: // phi * phi / (225.0 * log(100.0 * sqrt(m)));
 	double epsilon = 1e-5; // changed due to DGleich from: pow(2, exponent) / (48.0 * B);
 


### PR DESCRIPTION
Previously, unsigned int was used because the automatic conversion in Cython was not properly working. However, the Cython issue has been fixed in the meantime and other code in NetworKit relies on the fixed Cython version, too.