### PR TITLE
Not showing clustering coefficient for unsuited graphs in overview(G)

### DIFF
--- a/networkit/__init__.py
+++ b/networkit/__init__.py
@@ -101,6 +101,7 @@ def overview(G):
 	"""
 	n = G.numberOfNodes()
 	degrees = centrality.DegreeCentrality(G,ignoreSelfLoops=G.numberOfSelfLoops() == 0).run().scores()
+	numSelfLoops = G.numberOfSelfLoops()
 	def getIsolatedNodes(degrees):
 		sequence = sorted(degrees)
 		i = 0
@@ -124,9 +125,10 @@ def overview(G):
 	print("directed?\t\t\t{}".format("True" if G.isDirected() else "False"))
 	print("weighted?\t\t\t{}".format("True" if G.isWeighted() else "False"))
 	print("isolated nodes\t\t\t{}".format(getIsolatedNodes(degrees)))
-	print("self-loops\t\t\t{}".format(G.numberOfSelfLoops()))
+	print("self-loops\t\t\t{}".format(numSelfLoops))
 	print("density\t\t\t\t{:.6f}".format(G.density()))
-	print("clustering coefficient\t\t{:.6f}".format(getClusteringCoefficient(G)))
+	if numSelfLoops == 0 and not G.isDirected():
+		print("clustering coefficient\t\t{:.6f}".format(getClusteringCoefficient(G)))
 	print("min/max/avg degree\t\t{:d}, {:d}, {:.6f}".format(int(min(degrees)), int(max(degrees)), sum(degrees)/n))
 	print("degree assortativity\t\t{:.6f}".format(correlation.Assortativity(G, degrees).run().getCoefficient()))
 	cp = getComponentPartition(G)

--- a/networkit/cpp/centrality/LocalClusteringCoefficient.cpp
+++ b/networkit/cpp/centrality/LocalClusteringCoefficient.cpp
@@ -4,7 +4,7 @@
 namespace NetworKit {
 
 LocalClusteringCoefficient::LocalClusteringCoefficient(const Graph& G, bool turbo) : Centrality(G, false, false), turbo(turbo) {
-	if (G.isDirected()) throw std::runtime_error("Not implemented: Local clustering coefficient is currently not implemted for directed graphs");
+	if (G.isDirected()) throw std::runtime_error("Not implemented: Local clustering coefficient is currently not implemented for directed graphs");
 	if (G.numberOfSelfLoops()) throw std::runtime_error("Local Clustering Coefficient implementation does not support graphs with self-loops. Call Graph.removeSelfLoops() first.");
 }
 


### PR DESCRIPTION
Won't show the clustering coefficient information for graphs that are directed or have self-loops since the clustering coefficient implementation is not designed to handle those graphs.

Resolves #29.