### PR TITLE
Fixes many different unused warnings.

### DIFF
--- a/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
+++ b/networkit/cpp/generators/DynamicHyperbolicGenerator.cpp
@@ -290,7 +290,11 @@ void DynamicHyperbolicGenerator::getEventsFromNodeMovement(vector<GraphEvent> &r
 			#pragma omp critical
 			{
 				bool removed = quad.removeContent(toWiggle[j], oldphi, oldr);
+#ifndef NDEBUG
 				assert(removed);
+#else
+				((void)(removed));
+#endif
 				quad.addContent(toWiggle[j], angles[toWiggle[j]], radii[toWiggle[j]]);
 			}
 		}

--- a/networkit/cpp/generators/quadtree/QuadNode.h
+++ b/networkit/cpp/generators/quadtree/QuadNode.h
@@ -564,7 +564,11 @@ public:
 		auto distancePair = hyperbolicDistances(phi_q, r_q);
 		double probUB = prob(distancePair.first);
 		double probLB = prob(distancePair.second);
+#ifndef NDEBUG
 		assert(probLB <= probUB);
+#else
+        ((void)(probLB));
+#endif
 		if (probUB > 0.5) probUB = 1;//if we are going to take every second element anyway, no use in calculating expensive jumps
 		if (probUB == 0) return 0;
 		//TODO: return whole if probLB == 1

--- a/networkit/cpp/graph/Graph.h
+++ b/networkit/cpp/graph/Graph.h
@@ -291,7 +291,7 @@ private:
 			 (Aux::FunctionTraits<F>::arity >= 2) &&
 			 std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<2>::type>::value
 			 >::type* = (void*)0>
-	auto edgeLambda(F&f, node u, node v, edgeweight ew, edgeid id) const -> decltype(f(u, v, ew)) {
+	auto edgeLambda(F&f, node u, node v, edgeweight ew, edgeid /*id*/) const -> decltype(f(u, v, ew)) {
 		return f(u, v, ew);
 	}
 
@@ -306,7 +306,7 @@ private:
 			 (Aux::FunctionTraits<F>::arity >= 1) &&
 			 std::is_same<node, typename Aux::FunctionTraits<F>::template arg<1>::type>::value
 			 >::type* = (void*)0>
-	auto edgeLambda(F&f, node u, node v, edgeweight ew, edgeid id) const -> decltype(f(u, v)) {
+	auto edgeLambda(F&f, node u, node v, edgeweight /*ew*/, edgeid /*id*/) const -> decltype(f(u, v)) {
 			return f(u, v);
 	}
 
@@ -320,7 +320,7 @@ private:
 			 (Aux::FunctionTraits<F>::arity >= 1) &&
 			 std::is_same<edgeweight, typename Aux::FunctionTraits<F>::template arg<1>::type>::value
 			 >::type* = (void*)0>
-	auto edgeLambda(F&f, node u, node v, edgeweight ew, edgeid id) const -> decltype(f(u, ew)) {
+	auto edgeLambda(F&f, node u, node v, edgeweight ew, edgeid /*id*/) const -> decltype(f(u, ew)) {
 		return f(v, ew);
 	}
 
@@ -1218,7 +1218,7 @@ inline edgeid Graph::getInEdgeId<false>(node, index) const {
 
 
 template<bool graphIsDirected> // implementation for graphIsDirected == true
-inline bool Graph::useEdgeInIteration(node u, node v) const {
+inline bool Graph::useEdgeInIteration(node /* u */, node v) const {
 	return v != none;
 }
 

--- a/networkit/cpp/numerics/LAMG/Level/Level.h
+++ b/networkit/cpp/numerics/LAMG/Level/Level.h
@@ -41,15 +41,15 @@ public:
 		return A.numberOfRows();
 	}
 
-	virtual void coarseType(const Vector& xf, Vector& xc) const {}
+	virtual void coarseType(const Vector& /*xf*/, Vector& /*xc*/) const {}
 
-	virtual void restrict(const Vector& bf, Vector& bc) const {}
+	virtual void restrict(const Vector& /*bf*/, Vector& /*bc*/) const {}
 
-	virtual void restrict(const Vector& bf, Vector& bc, std::vector<Vector>& bStages) const {}
+	virtual void restrict(const Vector& /*bf*/, Vector& /*bc*/, std::vector<Vector>& /*bStages*/) const {}
 
-	virtual void interpolate(const Vector& xc, Vector& xf) const {}
+	virtual void interpolate(const Vector& /*xc*/, Vector& /*xf*/) const {}
 
-	virtual void interpolate(const Vector& xc, Vector& xf, const std::vector<Vector>& bStages) const {}
+	virtual void interpolate(const Vector& /*xc*/, Vector& /*xf*/, const std::vector<Vector>& /*bStages*/) const {}
 };
 
 

--- a/networkit/cpp/numerics/LAMG/Level/LevelAggregation.h
+++ b/networkit/cpp/numerics/LAMG/Level/LevelAggregation.h
@@ -32,7 +32,7 @@ public:
 };
 
 template<class Matrix>
-void LevelAggregation<Matrix>::coarseType(const Vector& xf, Vector& xc) const {
+void LevelAggregation<Matrix>::coarseType(const Vector& /*xf*/, Vector& xc) const {
 	xc = Vector(P.numberOfColumns(), 0.0);
 }
 

--- a/networkit/cpp/numerics/LAMG/MultiLevelSetup.h
+++ b/networkit/cpp/numerics/LAMG/MultiLevelSetup.h
@@ -318,7 +318,7 @@ count MultiLevelSetup<Matrix>::lowDegreeSweep(const Matrix& matrix, std::vector<
 	for (index i = 0; i < matrix.numberOfRows(); ++i) {
 		if ((int) matrix.nnzInRow(i) - degreeOffset <= (int)SETUP_ELIMINATION_MAX_DEGREE && fNode[i]) { // node i has degree <= 4 and can be eliminated
 			numFNodes++;
-			matrix.forNonZeroElementsInRow(i, [&](index j, edgeweight w){ // to maintain independence, mark all neighbors as not eliminated
+			matrix.forNonZeroElementsInRow(i, [&](index j, edgeweight /*w*/){ // to maintain independence, mark all neighbors as not eliminated
 				if (j != i)	{ // all neighbors of this f node are c nodes
 					fNode[j] = false;
 				}
@@ -503,7 +503,7 @@ void MultiLevelSetup<Matrix>::aggregateLooseNodes(const Matrix& strongAdjMatrix,
 	std::vector<index> looseNodes;
 	for (index i = 0; i < strongAdjMatrix.numberOfRows(); ++i) {
 		double max = std::numeric_limits<double>::min();
-		strongAdjMatrix.forNonZeroElementsInRow(i, [&](index j, double value) {
+		strongAdjMatrix.forNonZeroElementsInRow(i, [&](index /*j*/, double value) {
 			if (value > max) max = value;
 		});
 
@@ -594,7 +594,7 @@ void MultiLevelSetup<Matrix>::computeAffinityMatrix(const Matrix& matrix, const 
 	for (index i = 0; i < matrix.numberOfRows(); ++i) {
 		double nir = 1.0 / normSquared[i];
 		index cIdx = rowIdx[i];
-		matrix.forNonZeroElementsInRow(i, [&](index j, double val) {
+		matrix.forNonZeroElementsInRow(i, [&](index j, double /*val*/) {
 			double ij = 0.0;
 			for (index k = 0; k < tVs.size(); ++k) {
 				ij += tVs[k][i] * tVs[k][j];


### PR DESCRIPTION
When compiling code linking the C++ library of networkit, there are many different unused variable warnings. This fixes the ones I found. There are no other changes.

The code should merge cleanly both into master and into dev.