### PR TITLE
Signed 0 default in Octree

### DIFF
--- a/networkit/cpp/viz/Octree.h
+++ b/networkit/cpp/viz/Octree.h
@@ -207,7 +207,7 @@ struct OctreeNode {
 		for (index i = 0; i < numChildren; ++i) { // 0-bit => center - halfSideLength, 1-bit => center + halfSideLength, least-significant bit is lowest dimension
 			children[i].bBox.setSideLength(bBox.getHalfSideLength());
 			for (index d = 0; d < dimensions; ++d) {
-				if (((i & ~(~0 << (d+1))) >> d) == 0) { // 0-bit
+				if (((i & ~(~static_cast<index>(0) << (d+1))) >> d) == 0) { // 0-bit
 					children[i].bBox.getCenter()[d] -= children[i].bBox.getHalfSideLength();
 				} else {
 					children[i].bBox.getCenter()[d] += children[i].bBox.getHalfSideLength();


### PR DESCRIPTION
GCC 7 gives a warning about a signed bit-shift in Octree.h, which (in my opinion) poses a possible bug:

0 is signed by default, therefore ~0 is not (signed 0) and implementation specific, first comment here:
https://stackoverflow.com/a/2999588/2419265

The intended value here, if I understand correctly, is UINT_MAX or 0xffffffff, therefore it should be 0U, however in the bitness of index: therefore static_cast<index>(0). Thoroughly check this commit before merging.