### PR TITLE
Graph: remove unused parameters

### DIFF
--- a/networkit/cpp/graph/Graph.h
+++ b/networkit/cpp/graph/Graph.h
@@ -247,7 +247,7 @@ private:
 	 * error messages from the other declarations.
 	 */
 	template<class F, void* = (void*)0>
-	typename Aux::FunctionTraits<F>::result_type edgeLambda(F&f, ...) const {
+	typename Aux::FunctionTraits<F>::result_type edgeLambda(F&, ...) const {
 		// the strange condition is used in order to delay the eveluation of the static assert to the moment when this function is actually used
 		static_assert(! std::is_same<F, F>::value, "Your lambda does not support the required parameters or the parameters have the wrong type.");
 		return std::declval<typename Aux::FunctionTraits<F>::result_type>(); // use the correct return type (this won't compile)
@@ -278,7 +278,7 @@ private:
 			 std::is_same<edgeid, typename Aux::FunctionTraits<F>::template arg<2>::type>::value &&
 			 std::is_same<node, typename Aux::FunctionTraits<F>::template arg<1>::type>::value /* prevent f(v, weight, eid) */
 			 >::type* = (void*)0>
-	auto edgeLambda(F&f, node u, node v, edgeweight ew, edgeid id) const -> decltype(f(u, v, id)) {
+	auto edgeLambda(F&f, node u, node v, edgeweight, edgeid id) const -> decltype(f(u, v, id)) {
 		return f(u, v, id);
 	}
 
@@ -331,7 +331,7 @@ private:
 	 */
 	template<class F,
 			 void* = (void*)0>
-	auto edgeLambda(F&f, node u, node v, edgeweight ew, edgeid id) const -> decltype(f(v)) {
+	auto edgeLambda(F&f, node, node v, edgeweight, edgeid) const -> decltype(f(v)) {
 		return f(v);
 	}
 
@@ -348,7 +348,7 @@ private:
 	 * Calls the given BFS handle without distance parameter
 	 */
 	template <class F>
-	auto callBFSHandle(F &f, node u, count dist) const -> decltype(f(u)) {
+	auto callBFSHandle(F &f, node u, count) const -> decltype(f(u)) {
 		return f(u);
 	}
 


### PR DESCRIPTION
This prevents some compiler warnings for unused parameters by removing their names.