### PR TITLE
auxiliary/Parallel.h: add missing include

### DIFF
--- a/networkit/cpp/auxiliary/Parallel.h
+++ b/networkit/cpp/auxiliary/Parallel.h
@@ -5,6 +5,7 @@
 #define PARALLEL_H
 
 #include <atomic>
+#include <functional>
 
 #if ((defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__) || defined(__INTEL_COMPILER))) && defined _OPENMP
 #include <parallel/algorithm>


### PR DESCRIPTION
This adds the `functional` header for `std::greater` and `std::less`.