### PR TITLE
R-MAT generator: several fixes and improvements

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3031,18 +3031,27 @@ cdef class GMLGraphWriter:
 cdef extern from "cpp/io/EdgeListWriter.h":
 	cdef cppclass _EdgeListWriter "NetworKit::EdgeListWriter":
 		_EdgeListWriter() except +
-		_EdgeListWriter(char separator, node firstNode) except +
+		_EdgeListWriter(char separator, node firstNode, bool bothDirections) except +
 		void write(_Graph G, string path) nogil except +
 
 cdef class EdgeListWriter:
-	""" Reads and writes graphs in various edge list formats. The constructor takes a
-		seperator char and the ID of the first node as paraneters."""
+	""" Writes graphs in various edge list formats.
+
+	Parameters
+	----------
+	separator : string
+		The separator character.
+	firstNode : node
+		The id of the first node, this value will be added to all node ids
+	bothDirections : bool, optional
+		If undirected edges shall be written in both directions, i.e., as symmetric directed graph (default: false)
+	"""
 
 	cdef _EdgeListWriter _this
 
-	def __cinit__(self, separator, firstNode):
+	def __cinit__(self, separator, firstNode, bool bothDirections = False):
 		cdef char sep = stdstring(separator)[0]
-		self._this = _EdgeListWriter(sep, firstNode)
+		self._this = _EdgeListWriter(sep, firstNode, bothDirections)
 
 	def write(self, Graph G not None, path):
 		cdef string cpath = stdstring(path)

--- a/networkit/cpp/io/EdgeListWriter.cpp
+++ b/networkit/cpp/io/EdgeListWriter.cpp
@@ -14,24 +14,40 @@
 
 namespace NetworKit {
 
-EdgeListWriter::EdgeListWriter(char separator, node firstNode) : separator(separator), firstNode(firstNode) {}
+EdgeListWriter::EdgeListWriter(char separator, node firstNode, bool bothDirections) : separator(separator), firstNode(firstNode), bothDirections(bothDirections) {}
 
 void EdgeListWriter::write(const Graph& G, std::string path) {
-    std::ofstream file(path);
-    Aux::enforceOpened(file);
+	std::ofstream file(path);
+	Aux::enforceOpened(file);
 
-    if (G.isWeighted()) {
-        G.forEdges([&](node u, node v, double weight){
-            file << (u + firstNode) << separator << (v + firstNode) << separator << weight << std::endl;
-        });
-    } else {
-        G.forEdges([&](node u, node v){
-        	file << (u + firstNode) << separator << (v + firstNode) << std::endl;
-        });
-    }
+	auto writeWeightedEdge = [&](node u, node v, edgeweight weight) {
+		file << (u + firstNode) << separator << (v + firstNode) << separator << weight << std::endl;
+	};
+
+	auto writeUnweightedEdge = [&](node u, node v){
+		file << (u + firstNode) << separator << (v + firstNode) << std::endl;
+	};
+
+	if (G.isWeighted()) {
+		if (bothDirections) {
+			G.forNodes([&](node u) {
+				G.forEdgesOf(u, writeWeightedEdge);
+			});
+		} else {
+			G.forEdges(writeWeightedEdge);
+		}
+	} else {
+		if (bothDirections) {
+			G.forNodes([&](node u) {
+				G.forEdgesOf(u, writeUnweightedEdge);
+			});
+		} else {
+			G.forEdges(writeUnweightedEdge);
+		}
+	}
 
 
-    file.close();
+	file.close();
 
 }
 

--- a/networkit/cpp/io/EdgeListWriter.h
+++ b/networkit/cpp/io/EdgeListWriter.h
@@ -32,8 +32,9 @@ public:
 	/**
 	 * @param[in]	separator	character used to separate nodes in an edge line
 	 * @param[in]	firstNode	index of the first node in the file
+	 * @param[in]	bothDirections	for undirected graphs: if every edge shall be written in both directions (default: false)
 	 */
-	EdgeListWriter(char separator, node firstNode);
+	EdgeListWriter(char separator, node firstNode, bool bothDirections = false);
 
 	/**
 	 * Write the graph to a file.
@@ -46,6 +47,7 @@ protected:
 
 	char separator; 	//!< character separating nodes in an edge line
 	node firstNode;
+	bool bothDirections;
 };
 
 } /* namespace NetworKit */

--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -235,7 +235,7 @@ def getWriter(fileformat, **kwargs):
 	try:
 		# special case for custom Edge Lists
 		if fileformat == Format.EdgeList:
-			writer = EdgeListWriter(kwargs['separator'],kwargs['firstNode'])
+			writer = EdgeListWriter(**kwargs)
 		else:
 			writer = writers[fileformat]#(**kwargs)
 	except KeyError:


### PR DESCRIPTION
This fixes several issues and improves the fitting to generate graphs with a better fit to the graph that shall be replicated. In particular this contains the following changes:

* EdgeListWriter is extended to support writing symmetric directed graphs.
* The R-MAT generator does not produce graphs with deleted nodes anymore as they create problems in so many places.
* The R-MAT generator for undirected graphs produces graphs with exactly the requested edge factor. The graphs also do not contain any self-loops anymore.
* The R-MAT generator for weighted graphs produces more edges when nodes shall be deleted to compensate for the edges that are lost due to deleting nodes. Here, self-loops are still possible.
* kronfit (for fitting) is called with an explicit output file (the previous assumption on the output file name was not compatible with the code obtained from SNAP) and the parsing is more flexible (also didn't work for me before the change). Further, both input and output file for kronfit are written to a temporary directory so no explicit working directory needs to be provided anymore.

I am wondering about R-MAT for weighted graphs. Is anybody using it? If yes, what kind of behavior would you expect? Shall there be self-loops? If not, should the number of edges match exactly the requested factor?