### PR TITLE
Several fixes for the LFR generator

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -2813,7 +2813,9 @@ cdef class LFRGenerator(Algorithm):
 			# mixing parameter
 			#print("mixing parameter")
 			gen.setMu(mu)
-			refImplParams = "-N {0} -k {1} -maxk {2} -mu {3} -minc {4} -maxc {5} -t1 {6} -t2 {7}".format(n * scale, avgDegree, maxDegree, mu, communityMinSize, communityMaxSize, nodeDegreeExp, communityExp)
+			# Add some small constants to the parameters for the reference implementation to
+			# ensure it won't say the average degree is too low.
+			refImplParams = "-N {0} -k {1} -maxk {2} -mu {3} -minc {4} -maxc {5} -t1 {6} -t2 {7}".format(n * scale, avgDegree + 1e-4, maxDegree, mu, max(communityMinSize, 3), communityMaxSize, nodeDegreeExp + 0.001, communityExp)
 			cls.params["refImplParams"] = refImplParams
 			print(refImplParams)
 		else:

--- a/networkit/cpp/generators/LFRGenerator.cpp
+++ b/networkit/cpp/generators/LFRGenerator.cpp
@@ -131,7 +131,9 @@ NetworKit::Graph NetworKit::LFRGenerator::generateIntraClusterGraph(std::vector<
 	// check if sum of degrees is even and fix if necessary
 	count intraDegSum = std::accumulate(intraDegreeSequence.begin(), intraDegreeSequence.end(), 0);
 
-	while (intraDegSum % 2 != 0) {
+	DEBUG("Possibly correcting the degree sequence");
+
+	for (index j = 0; intraDegSum % 2 != 0 && j < intraDegreeSequence.size(); ++j) {
 		index i = Aux::Random::index(intraDegreeSequence.size());
 		node u = localToGlobalNode[i];
 		if (Aux::Random::real() >= 0.5) {
@@ -151,6 +153,7 @@ NetworKit::Graph NetworKit::LFRGenerator::generateIntraClusterGraph(std::vector<
 		}
 	}
 
+	DEBUG("Generating intra-cluster graph");
 		EdgeSwitchingMarkovChainGenerator intraGen(intraDegreeSequence, true);
 	/* even though the sum is even the degree distribution isn't necessarily realizable.
 	Disabling the check means that some edges might not be created because of this but at least we will get a graph. */


### PR DESCRIPTION
This fixes several issues in the LFR generator:

* In some cases, there was an infinite loop when communities had very special degree distributions
* The fitting of the mu value for the "vanilla" LFR generator was wrong, this has been corrected
* The maximum community size is now adjusted if necessary to fit the largest degree
* The parameters for the reference implementation are slightly adjusted to make sure the external implementation fails less (however, additional changes in the external code are required to support minimum degrees of 1).