### PR TITLE
SConstruct: Improved reading external library paths from build.conf

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -132,14 +132,8 @@ else:
 	conf.read([confPath])     # read the configuration file
 
 	## compiler
-	if compiler is None:
-		cppComp = conf.get("compiler", "cpp", "gcc")
-	else:
-		cppComp = compiler
-	defines = conf.get("compiler", "defines", [])		# defines are optional
-	if defines is not []:
-		defines = defines.split(",")
-
+	cppComp = compiler or conf.get("compiler", "cpp", "gcc")
+	defines = conf.get("compiler", "defines", "").split(",")		# defines are optional
 
 	## C++14 support
 	if stdflag is None:
@@ -154,27 +148,22 @@ else:
 		conf.set("compiler","std14", stdflag)
 
 	## includes
-	stdInclude = conf.get("includes", "std", "")      # includes for the standard library - may not be needed
-	gtestInclude = conf.get("includes", "gtest")
-	if conf.has_option("includes", "tbb"):
-		tbbInclude = conf.get("includes", "tbb", "")
-	else:
-		tbbInclude = ""
+	# Evaluates the [includes] section of the build.conf file.
+	# Includes may include std, gtest, tbb
+	includes = dict(conf.items("includes"))
 
 	## libraries
-	gtestLib = conf.get("libraries", "gtest")
-	if conf.has_option("libraries", "tbb"):
-		tbbLib = conf.get("libraries", "tbb", "")
-	else:
-		tbbLib = ""
+	# Evaluates the [libraries] section of the build.conf file.
+	# Libraries may include gtest, tbb
+	libraries = dict(conf.items("libraries"))
 
 	env["CC"] = cppComp
 	env["CXX"] = cppComp
 
 	env.Append(CPPDEFINES=defines)
-	env.Append(CPPPATH = [stdInclude, gtestInclude, tbbInclude])
-	env.Append(LIBS = ["gtest"])
-	env.Append(LIBPATH = [gtestLib, tbbLib])
+	env.Append(CPPPATH = includes.values())
+	env.Append(LIBS = libraries.keys())
+	env.Append(LIBPATH = libraries.values())
 
 	with open(confPath, "w") as f:
 		conf.write(f)

--- a/SConstruct
+++ b/SConstruct
@@ -5,6 +5,21 @@ import ConfigParser
 
 home_path = os.environ['HOME']
 
+
+class DefaultConfigParser(ConfigParser.ConfigParser):
+	def get_default(self, section, option, default=None, raw=False, vars=None):
+		"""Get an option value for a given section.
+
+		If the option exists in the section, get_default behaves exactly like
+		get(). If not, default is returned (if not explicitly set: None).
+		"""
+
+		try:
+			return self.get(section, option, raw=raw, vars=vars)
+		except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+			return default
+
+
 def checkStd(compiler):
 	sample = open("sample.cpp", "w")
 	sample.write("""
@@ -128,19 +143,16 @@ else:
 		print("Use the file build.conf.example to create your build.conf")
 		Exit(1)
 
-	conf = ConfigParser.ConfigParser()
+	conf = DefaultConfigParser()
 	conf.read([confPath])     # read the configuration file
 
+
 	## compiler
-	cppComp = compiler or conf.get("compiler", "cpp", "gcc")
-	defines = conf.get("compiler", "defines", "").split(",")		# defines are optional
+	cppComp = compiler or conf.get_default("compiler", "cpp", "gcc")
+	defines = conf.get_default("compiler", "defines", "").split(",")		# defines are optional
 
 	## C++14 support
-	if stdflag is None:
-		try:
-			stdflag = conf.get("compiler", "std14")
-		except:
-			pass
+	stdflag = stdflag or conf.get_default("compiler", "std14")
 	if stdflag is None or len(stdflag) == 0:
 		# do test compile
 		stdflag = checkStd(cppComp)


### PR DESCRIPTION
These changes to SConstruct allow a simple way to include external projects with custom include / library paths by extending the `[libraries]` and `[includes]` sections of the `build.conf` file:

```
[libraries]
expro = /home/user/share/expro/lib

[includes]
expro = /home/user/share/expro/include
```
Effects:

 * `-I/home/user/share/expro/include` is added to all compiler calls
 * `-L/home/user/share/expro/lib` is added to all linker calls
 * `-lexpro` is added to all linker calls (determined by the `expro` key in the `[libraries]` section).

The inclusion of `gest`, `std` and `tbb` works as before.

I'd propose including these in the main repository as they streamline the integration of external projects for all contributors (and all forks).

Backported from [rolandglantz/networkit](https://github.com/rolandglantz/networkit).