### PR TITLE
SConstruct: fixes for SCons 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
           packages:
             - g++-4.8
             - scons
+            - python-configparser
             - libgtest-dev
       install:
        - mkdir ~/gtest && cd ~/gtest
@@ -50,6 +51,7 @@ matrix:
             - g++-5
             - clang-3.8
             - scons
+            - python-configparser
             - libgtest-dev
             - subversion
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
         - brew tap homebrew/versions
         - brew install gcc48
         - brew install scons
+        - pip install configparser
       install:
         - git clone https://github.com/google/googletest.git ~/gtest/
         - cd ~/gtest/googletest/
@@ -80,6 +81,7 @@ matrix:
         - brew tap homebrew/versions
         - brew install scons
         - brew install llvm37
+        - pip install configparser
       install:
         # install gtest
         - git clone https://github.com/google/googletest.git ~/gtest/

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import fnmatch
-import ConfigParser
+import configparser
 
 home_path = os.environ['HOME']
 
@@ -46,7 +46,7 @@ def getSourceFiles(target, optimize):
 
 	# walk source directory and find ONLY .cpp files
 	for (dirpath, dirnames, filenames) in os.walk(srcDir):
-	    for name in fnmatch.filter(filenames, "*.cpp"):
+		for name in fnmatch.filter(filenames, "*.cpp"):
 			source.append(os.path.join(dirpath, name))
 
 	# exclude files depending on target, executables will be addes later
@@ -135,16 +135,16 @@ else:
 		print("Use the file build.conf.example to create your build.conf")
 		Exit(1)
 
-	conf = ConfigParser.ConfigParser()
+	conf = configparser.ConfigParser()
 	conf.read([confPath])     # read the configuration file
 
 	## compiler
 	if compiler is None:
-		cppComp = conf.get("compiler", "cpp", "gcc")
+		cppComp = conf.get("compiler", "cpp", fallback="gcc")
 	else:
 		cppComp = compiler
 	if defines is None:
-		defines = conf.get("compiler", "defines", [])		# defines are optional
+		defines = conf.get("compiler", "defines", fallback=[])		# defines are optional
 	if defines is not []:
 		defines = defines.split(",")
 
@@ -152,7 +152,7 @@ else:
 	## C++14 support
 	if stdflag is None:
 		try:
-			stdflag = conf.get("compiler", "std14")
+			stdflag = conf.get("compiler", fallback="std14")
 		except:
 			pass
 	if stdflag is None or len(stdflag) == 0:
@@ -162,17 +162,17 @@ else:
 		conf.set("compiler","std14", stdflag)
 
 	## includes
-	stdInclude = conf.get("includes", "std", "")      # includes for the standard library - may not be needed
+	stdInclude = conf.get("includes", "std", fallback="")      # includes for the standard library - may not be needed
 	gtestInclude = conf.get("includes", "gtest")
 	if conf.has_option("includes", "tbb"):
-		tbbInclude = conf.get("includes", "tbb", "")
+		tbbInclude = conf.get("includes", "tbb", fallback="")
 	else:
 		tbbInclude = ""
 
 	## libraries
 	gtestLib = conf.get("libraries", "gtest")
 	if conf.has_option("libraries", "tbb"):
-		tbbLib = conf.get("libraries", "tbb", "")
+		tbbLib = conf.get("libraries", "tbb", fallback="")
 	else:
 		tbbLib = ""
 


### PR DESCRIPTION
This fixes the indentation for Python 3 and migrates from (Python 2) `ConfigParser` to (Python 3) `configparser`. This allows building with scons 3.0 with Python 3 (yes, this means no more dependency on Python 2). For Python 2 support, installing the `configparser` backport from pip is necessary now. I fixed this for Travis, but probably this should also be documented or automated somewhere?