### PR TITLE
Fix maximum for closeness scores

### DIFF
--- a/networkit/cpp/centrality/Closeness.cpp
+++ b/networkit/cpp/centrality/Closeness.cpp
@@ -67,7 +67,7 @@ void Closeness::run() {
 }
 
 double Closeness::maximum() {
-	return (double) 1 / (G.numberOfNodes() - 1);
+	return normalized ? 1 : (1.0f / (G.numberOfNodes() - 1));
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/Closeness.cpp
+++ b/networkit/cpp/centrality/Closeness.cpp
@@ -67,7 +67,7 @@ void Closeness::run() {
 }
 
 double Closeness::maximum() {
-	return normalized ? 1 : (1.0f / (G.numberOfNodes() - 1));
+	return normalized ? 1.0f : (1.0f / (G.numberOfNodes() - 1));
 }
 
 } /* namespace NetworKit */


### PR DESCRIPTION
Resolves incorrect `maximum` method mentioned in #81.