### PR TITLE
Compatibility with NetworkX 2.0

### DIFF
--- a/networkit/nxadapter.py
+++ b/networkit/nxadapter.py
@@ -28,7 +28,7 @@ def nx2nk(nxG, weightAttr=None):
 		nkG = graph.Graph(z, weighted=True, directed=nxG.is_directed())
 		for (u_, v_) in nxG.edges():
 			u, v = idmap[u_], idmap[v_]
-			w = nxG.edge[u_][v_][weightAttr]
+			w = nxG[u_][v_][weightAttr]
 			nkG.addEdge(u, v, w)
 	else:
 		nkG = graph.Graph(z, directed=nxG.is_directed())


### PR DESCRIPTION
nxG.edge is removed from NetworkX 2.0, to compatable with boath NetworkX 2.0 and Network 1.1X, we can just use nxG[u_][v_][weightAttr] instead.