### PR TITLE
Configparser backwards compatibility

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,14 @@
 import os
 import subprocess
 import fnmatch
-import configparser
+import pip
+
+# Make sure configparser is available in case scons is run as a Python2 package.
+try:
+    import configparser
+except:
+    pip.main(['install', 'configparser'])
+    import configparser
 
 home_path = os.environ['HOME']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tabulate
 seaborn
 sklearn
 ipython
+configparser

--- a/setup_util.py
+++ b/setup_util.py
@@ -58,6 +58,11 @@ def installExternalPythonPackages():
 		del sklearn
 	except:
 		installPackage('sklearn')
+	try:
+		import configparser
+		del configparser
+	except:
+		installPackage('configparser')
 	ipythonStatus = os.system('pip3 show ipython')
 	if ipythonStatus != 0:
 		installPackage('ipython')


### PR DESCRIPTION
Since we're now using the built-in `configparser` module in Python3, there should be a backport for python2.7 users. For now we can simply install the `configparser` package. This way, on python3 `import configparser` will use the built-in parser while on python3 this import will use the installed package.