### PR TITLE
Revert "SConstruct: fixes for SCons 3"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
           packages:
             - g++-4.8
             - scons
-            - python-configparser
             - libgtest-dev
       install:
        - mkdir ~/gtest && cd ~/gtest
@@ -30,7 +29,6 @@ matrix:
         - brew tap homebrew/versions
         - brew install gcc48
         - brew install scons
-        - pip install configparser
       install:
         - git clone https://github.com/google/googletest.git ~/gtest/
         - cd ~/gtest/googletest/
@@ -52,7 +50,6 @@ matrix:
             - g++-5
             - clang-3.8
             - scons
-            - python-configparser
             - libgtest-dev
             - subversion
       install:
@@ -81,7 +78,6 @@ matrix:
         - brew tap homebrew/versions
         - brew install scons
         - brew install llvm37
-        - pip install configparser
       install:
         # install gtest
         - git clone https://github.com/google/googletest.git ~/gtest/

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import fnmatch
-import configparser
+import ConfigParser
 
 home_path = os.environ['HOME']
 
@@ -46,7 +46,7 @@ def getSourceFiles(target, optimize):
 
 	# walk source directory and find ONLY .cpp files
 	for (dirpath, dirnames, filenames) in os.walk(srcDir):
-		for name in fnmatch.filter(filenames, "*.cpp"):
+	    for name in fnmatch.filter(filenames, "*.cpp"):
 			source.append(os.path.join(dirpath, name))
 
 	# exclude files depending on target, executables will be addes later
@@ -138,16 +138,16 @@ else:
 		print("Use the file build.conf.example to create your build.conf")
 		Exit(1)
 
-	conf = configparser.ConfigParser()
+	conf = ConfigParser.ConfigParser()
 	conf.read([confPath])     # read the configuration file
 
 	## compiler
 	if compiler is None:
-		cppComp = conf.get("compiler", "cpp", fallback="gcc")
+		cppComp = conf.get("compiler", "cpp", "gcc")
 	else:
 		cppComp = compiler
 	if defines is None:
-		defines = conf.get("compiler", "defines", fallback=[])		# defines are optional
+		defines = conf.get("compiler", "defines", [])		# defines are optional
 	if defines is not []:
 		defines = defines.split(",")
 
@@ -155,7 +155,7 @@ else:
 	## C++14 support
 	if stdflag is None:
 		try:
-			stdflag = conf.get("compiler", fallback="std14")
+			stdflag = conf.get("compiler", "std14")
 		except:
 			pass
 	if stdflag is None or len(stdflag) == 0:
@@ -165,17 +165,17 @@ else:
 		conf.set("compiler","std14", stdflag)
 
 	## includes
-	stdInclude = conf.get("includes", "std", fallback="")      # includes for the standard library - may not be needed
+	stdInclude = conf.get("includes", "std", "")      # includes for the standard library - may not be needed
 	gtestInclude = conf.get("includes", "gtest")
 	if conf.has_option("includes", "tbb"):
-		tbbInclude = conf.get("includes", "tbb", fallback="")
+		tbbInclude = conf.get("includes", "tbb", "")
 	else:
 		tbbInclude = ""
 
 	## libraries
 	gtestLib = conf.get("libraries", "gtest")
 	if conf.has_option("libraries", "tbb"):
-		tbbLib = conf.get("libraries", "tbb", fallback="")
+		tbbLib = conf.get("libraries", "tbb", "")
 	else:
 		tbbLib = ""
 


### PR DESCRIPTION
Reverts kit-parco/networkit#77.

**Issues:**
- Automatically installing the configparser compatibility package on Python2 doesn't work reliably for some of our test systems. We're unable to install the package during runtime and import it afterwards. A restart of the scons script would be needed.
- There seems to be an internal issue with scons3. When installed through pip3 it won't work out of the box since it won't look in the python3 package folders to find additional scripts. A manual symlink seems to be needed.