### PR TITLE
Backwards compatible configparser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
           packages:
             - g++-4.8
             - scons
+            - python-configparser
             - libgtest-dev
       install:
        - mkdir ~/gtest && cd ~/gtest
@@ -29,6 +30,7 @@ matrix:
         - brew tap homebrew/versions
         - brew install gcc48
         - brew install scons
+        - pip install configparser
       install:
         - git clone https://github.com/google/googletest.git ~/gtest/
         - cd ~/gtest/googletest/
@@ -50,6 +52,7 @@ matrix:
             - g++-5
             - clang-3.8
             - scons
+            - python-configparser
             - libgtest-dev
             - subversion
       install:
@@ -78,6 +81,7 @@ matrix:
         - brew tap homebrew/versions
         - brew install scons
         - brew install llvm37
+        - pip install configparser
       install:
         # install gtest
         - git clone https://github.com/google/googletest.git ~/gtest/
@@ -103,9 +107,9 @@ script:
  - echo $OPENMP_LIB
  - echo $OPENMP_INCLUDE
  - $CXX --version
- - scons --optimize=Dbg --target=Tests --std=c++11 -j2
+ - scons --optimize=Opt --target=Tests --std=c++11 -j2
  - export OMP_NUM_THREADS=2
- - ./NetworKit-Tests-Dbg -t
+ - ./NetworKit-Tests-Opt -t
 
 notifications:
   email: false

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,14 @@
 import os
 import subprocess
 import fnmatch
-import configparser
+import sys
+
+if sys.version_info >= (3,0):
+    import configparser as cp
+    getConf = lambda conf, sec, name, fb: conf.get(sec, name, fallback=fb)
+else:
+    import ConfigParser as cp
+    getConf = lambda conf, sec, name, fb: conf.get(sec, name, fb)
 
 home_path = os.environ['HOME']
 
@@ -138,16 +145,16 @@ else:
 		print("Use the file build.conf.example to create your build.conf")
 		Exit(1)
 
-	conf = configparser.ConfigParser()
+	conf = cp.ConfigParser()
 	conf.read([confPath])     # read the configuration file
 
 	## compiler
 	if compiler is None:
-		cppComp = conf.get("compiler", "cpp", fallback="gcc")
+		cppComp = getConf(conf, "compiler", "cpp", "gcc")
 	else:
 		cppComp = compiler
 	if defines is None:
-		defines = conf.get("compiler", "defines", fallback=[])		# defines are optional
+		defines = getConf(conf, "compiler", "defines", [])		# defines are optional
 	if defines is not []:
 		defines = defines.split(",")
 
@@ -155,7 +162,7 @@ else:
 	## C++14 support
 	if stdflag is None:
 		try:
-			stdflag = conf.get("compiler", fallback="std14")
+			stdflag = getConf(conf, "compiler", "std14")
 		except:
 			pass
 	if stdflag is None or len(stdflag) == 0:
@@ -165,17 +172,17 @@ else:
 		conf.set("compiler","std14", stdflag)
 
 	## includes
-	stdInclude = conf.get("includes", "std", fallback="")      # includes for the standard library - may not be needed
-	gtestInclude = conf.get("includes", "gtest")
+	stdInclude = getConf(conf, "includes", "std", "")      # includes for the standard library - may not be needed
+	gtestInclude = getConf(conf, "includes", "gtest", None)
 	if conf.has_option("includes", "tbb"):
-		tbbInclude = conf.get("includes", "tbb", fallback="")
+		tbbInclude = getConf(conf, "includes", "tbb", "")
 	else:
 		tbbInclude = ""
 
 	## libraries
-	gtestLib = conf.get("libraries", "gtest")
+	gtestLib = getConf(conf, "libraries", "gtest", None)
 	if conf.has_option("libraries", "tbb"):
-		tbbLib = conf.get("libraries", "tbb", fallback="")
+		tbbLib = getConf(conf, "libraries", "tbb", "")
 	else:
 		tbbLib = ""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ tabulate
 seaborn
 sklearn
 ipython
-configparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tabulate
 seaborn
 sklearn
 ipython
+configparser

--- a/setup_util.py
+++ b/setup_util.py
@@ -58,6 +58,11 @@ def installExternalPythonPackages():
 		del sklearn
 	except:
 		installPackage('sklearn')
+	try:
+		import configparser
+		del configparser
+	except:
+		installPackage('configparser')
 	ipythonStatus = os.system('pip3 show ipython')
 	if ipythonStatus != 0:
 		installPackage('ipython')

--- a/setup_util.py
+++ b/setup_util.py
@@ -58,11 +58,6 @@ def installExternalPythonPackages():
 		del sklearn
 	except:
 		installPackage('sklearn')
-	try:
-		import configparser
-		del configparser
-	except:
-		installPackage('configparser')
 	ipythonStatus = os.system('pip3 show ipython')
 	if ipythonStatus != 0:
 		installPackage('ipython')


### PR DESCRIPTION
If the user is running SCons3 on Python3 it will automatically use the respective configparser module from Python3. Otherwise it will default to using the old ConfigParser package on Python 2.

This is still not ideal since we're not able to use the new configparser features on Python 2.