### PR TITLE
Travis: Fix custom gcc installation on macOS images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ matrix:
       before_install:
         - brew update
         - brew tap homebrew/versions
+        - brew cask uninstall --force oclint # See https://github.com/travis-ci/travis-ci/issues/8826 for details.
         - brew install gcc49
-        - brew link --overwrite gcc@4.9
         - brew install scons
         - pip2 install configparser
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
        - make
        - cd -
 
-    - env: CC=gcc-4.9 CXX=g++-4.9
+    - env: CC=gcc-6 CXX=g++-6
       os: osx
       sudo: false
       before_install:
         - brew update
         - brew tap homebrew/versions
         - brew cask uninstall --force oclint # See https://github.com/travis-ci/travis-ci/issues/8826 for details.
-        - brew install gcc49
+        - brew install gcc@6
         - brew install scons
         - pip2 install configparser
       install:


### PR DESCRIPTION
Travis updated their macOS images to include `oclint` which will provide a default gcc binary. This leads to failure during installation of a custom gcc binary through Homebrew.

This PR addresses the issue by uninstalling oclint beforehand.