### PR TITLE
Fix travis failures due to testTimer

### DIFF
--- a/networkit/cpp/auxiliary/test/AuxGTest.cpp
+++ b/networkit/cpp/auxiliary/test/AuxGTest.cpp
@@ -117,23 +117,6 @@ TEST_F(AuxGTest, testRandomProbability) {
 }
 
 
-TEST_F(AuxGTest, testTimer) {
-	int64_t sleepTime = 1000; // sleep time in ms
-	int64_t tolerance = 20;
-
-	Aux::Timer timer;
-	DEBUG("sleeping for ", sleepTime, " ms");
-	timer.start();
-	std::this_thread::sleep_for(std::chrono::milliseconds(sleepTime));
-	timer.stop();
-	std::chrono::duration<int64_t, std::milli> elapsed = timer.elapsed();
-	int64_t ec = elapsed.count();
-
-	EXPECT_LE(sleepTime - tolerance, ec) << "elapsed time should be roughly equal to sleep time";
-	EXPECT_GE(sleepTime + tolerance, ec) << "elapsed time should be roughly to sleep time";
-}
-
-
 TEST_F(AuxGTest, testBinomial) {
 	EXPECT_EQ(1, Aux::MissingMath::binomial(7,0));
 	EXPECT_EQ(7, Aux::MissingMath::binomial(7,1));


### PR DESCRIPTION
testTimer causes Travis CI to fail sporadically.
We cannot rely on the OS' scheduler to wake up the test within a certain time frame. This is especially unreliable on busy systems (like the Travis servers).

Turning this test into a benchmark allows us to still run it manually without causing CI failures.

@kolja-esders Please check if this makes sense.