### PR TITLE
fix error message for profiling

### DIFF
--- a/networkit/profiling/profiling.py
+++ b/networkit/profiling/profiling.py
@@ -909,7 +909,7 @@ class Profile:
 					self.verbosePrint("Correlation: " + name + " <-> " + nameB, level=1)
 					self.__correlations[category][name][nameB]["stat"] = correlation
 			except Exception as e:
-				self.verbosePrint("Error (Post Processing): " + jobType + " - " + nam-e, level=-1)
+				self.verbosePrint("Error (Post Processing): " + jobType + " - " + name, level=-1)
 				self.verbosePrint(str(e), level=-1)
 
 		pool.join()


### PR DESCRIPTION
This fixes a minor spelling bug, which led to a `NameError` instead of the actual one.

Thanks for considering this!