### PR TITLE
Remove timeout from LAMG test

### DIFF
--- a/networkit/cpp/numerics/test/LAMGGTest.cpp
+++ b/networkit/cpp/numerics/test/LAMGGTest.cpp
@@ -47,7 +47,6 @@ TEST_F(LAMGGTest, testSmallGraphs) {
 
 
 		LAMGSolverStatus status;
-		status.maxConvergenceTime = 10 * 60 * 1000;
 		status.desiredResidualReduction = 1e-6 * b.length() / (hierarchy.at(0).getLaplacian() * x - b).length(); // needed for getting a relative residual <= 1e-6
 
 		Vector result = x;


### PR DESCRIPTION
Timeouts on tests are problematic as tests might take much longer
on shared CI servers than they do locally.

Fixes #125 