### PR TITLE
io/KONECTGraphReader: Fix default constructor

### DIFF
--- a/networkit/cpp/io/KONECTGraphReader.h
+++ b/networkit/cpp/io/KONECTGraphReader.h
@@ -28,14 +28,11 @@ namespace NetworKit {
 class KONECTGraphReader: public NetworKit::GraphReader {
 
 public:
-
-	KONECTGraphReader() = default; //nullary constructor for Python shell
-
 	/**
 	 * @param[in]	ignoreLoops	ignores loops in the input graph file, if set to true
 	 * @param[in]	separator	character used to separate values of a line
 	 */
-	KONECTGraphReader(char separator, bool ignoreLoops=false);
+	KONECTGraphReader(char separator=' ', bool ignoreLoops=false);
 
 	/**
 	 * Given the path of an input file, read the graph contained.
@@ -49,8 +46,6 @@ protected:
 	char separator; 	//!< character separating nodes in an edge line
 	std::string commentPrefix;
 	node firstNode;
-	bool continuous;
-//	std::unordered_map<index,node> mapNodeIds;
 	bool ignoreLoops;
 
 private:


### PR DESCRIPTION
The default constructor in the KONECTGraphReader class did not
properly initialize all member variables. Remove the default
constructor and assign default values to the non-default
constructor so that it can be called without arguments.

This commit also cleans up unused variables from the class.