### PR TITLE
Implement equality and hashing of partitions

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3767,6 +3767,65 @@ cdef class Partition:
 		"""
 		return self._this.getSubsetIds()
 
+	def __eq__(self, Partition other not None):
+		""" Compare self to other partition.
+
+		Equality is independent of the used partition
+		ids. This tries to construct a mapping between the
+		partition ids and returns True if such a mapping can
+		be constructed.
+
+		Parameters
+		----------
+		other : Partition
+			The partition to compare to.
+
+		Returns
+		-------
+		bool
+			If the partitions are equal.
+		"""
+		if self._this.numberOfElements() != other._this.numberOfElements():
+			return False
+
+		cdef index i = 0
+		cdef dict selfToOther = dict()
+		for index in range(self._this.numberOfElements()):
+			selfSubset = self[i]
+			if selfSubset in selfToOther:
+				if selfToOther[selfSubset] != other[i]:
+					return False
+			else:
+				selfToOther[selfSubset] = other[i]
+		return True
+
+	def __hash__(self):
+		"""
+		Hash the partition.
+
+		This hash value does not depend on the actually used
+		partition ids. Instead, it hashes a list of new
+		partition ids that are assigned in a canonical way.
+
+		Returns
+		-------
+		int
+			A hash value.
+		"""
+		cdef list canonicIds = list()
+		cdef dict toCanonicId = dict()
+
+		cdef index i = 0
+		cdef object nextId = 0
+		for i in range(self._this.numberOfElements()):
+			s = self[i]
+			if not s in toCanonicId:
+				toCanonicId[s] = nextId
+				nextId += 1
+
+			canonicIds.append(toCanonicId[s])
+		return hash(tuple(canonicIds))
+
 
 cdef extern from "cpp/structures/Cover.h":
 	cdef cppclass _Cover "NetworKit::Cover":


### PR DESCRIPTION
This allows to quickly check partitions on equality. Further, it allows to store partitions in a Python set. This allows to quickly compute the number of different partitions in a large set of partitions.

Note that modifying partitions that are stored in a set or even used as keys in a dict leads to undefined behavior. A cleaner way to implement this would thus be to have some kind of "frozen" partition but I'm not sure how to implement that or if it is woth the effort.