### PR TITLE
Add algorithm to compute the difference of two graphs

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -6621,8 +6621,126 @@ cdef class KatzCentrality(Centrality):
 		self._G = G
 		self._this = new _KatzCentrality(G._this, alpha, beta, tol)
 
+cdef extern from "cpp/dynamics/GraphDifference.h":
+	cdef cppclass _GraphDifference "NetworKit::GraphDifference"(_Algorithm):
+		_GraphDifference(const _Graph &G1, const _Graph &G2) except +
+		void run() except +
+		vector[_GraphEvent] getEdits() except +
+		count getNumberOfEdits() except +
+		count getNumberOfNodeAdditions() except +
+		count getNumberOfNodeRemovals() except +
+		count getNumberOfNodeRestorations() except +
+		count getNumberOfEdgeAdditions() except +
+		count getNumberOfEdgeRemovals() except +
+		count getNumberOfEdgeWeightUpdates() except +
 
+cdef class GraphDifference(Algorithm):
+	"""
+	Calculate the edge difference between two graphs.
 
+	This calculates which graph edge additions or edge removals are
+	necessary to transform one given graph into another given graph.
+
+	Both graphs need to have the same node set, directed graphs are not
+	supported currently.
+
+	Note that edge weight differences are not detected but edge
+	addition events set the correct edge weight.
+
+	Parameters
+	----------
+	G1 : Graph
+		The first graph to compare
+	G2 : Graph
+		The second graph to compare
+	"""
+	cdef Graph _G1, _G2
+
+	def __cinit__(self, Graph G1, Graph G2):
+		self._this = new _GraphDifference(G1._this, G2._this)
+		self._G1 = G1
+		self._G2 = G2
+
+	def getEdits(self):
+		""" Get the required edits.
+
+		Returns
+		-------
+		list
+			A list of graph events
+		"""
+		cdef _GraphEvent ev
+		return [GraphEvent(ev.type, ev.u, ev.v, ev.w) for ev in (<_GraphDifference*>(self._this)).getEdits()]
+
+	def getNumberOfEdits(self):
+		""" Get the required number of edits.
+
+		Returns
+		-------
+		int
+			The number of edits.
+		"""
+		return (<_GraphDifference*>(self._this)).getNumberOfEdits()
+
+	def getNumberOfNodeAdditions(self):
+		""" Get the required number of node additions.
+
+		Returns
+		-------
+		int
+			The number of node additions.
+		"""
+		return (<_GraphDifference*>(self._this)).getNumberOfNodeAdditions()
+
+	def getNumberOfNodeRemovals(self):
+		""" Get the required number of node removals.
+
+		Returns
+		-------
+		int
+			The number of node removals.
+		"""
+		return (<_GraphDifference*>(self._this)).getNumberOfNodeRemovals()
+
+	def getNumberOfNodeRestorations(self):
+		""" Get the required number of node restorations.
+
+		Returns
+		-------
+		int
+			The number of node restorations.
+		"""
+		return (<_GraphDifference*>(self._this)).getNumberOfNodeRestorations()
+
+	def getNumberOfEdgeAdditions(self):
+		""" Get the required number of edge additions.
+
+		Returns
+		-------
+		int
+			The number of edge additions.
+		"""
+		return (<_GraphDifference*>(self._this)).getNumberOfEdgeAdditions()
+
+	def getNumberOfEdgeRemovals(self):
+		""" Get the required number of edge removals.
+
+		Returns
+		-------
+		int
+			The number of edge removals.
+		"""
+		return (<_GraphDifference*>(self._this)).getNumberOfEdgeRemovals()
+
+	def getNumberOfEdgeWeightUpdates(self):
+		""" Get the required number of edge weight updates.
+
+		Returns
+		-------
+		int
+			The number of edge weight updates.
+		"""
+		return (<_GraphDifference*>(self._this)).getNumberOfEdgeWeightUpdates()
 
 cdef extern from "cpp/centrality/ApproxBetweenness.h":
 	cdef cppclass _ApproxBetweenness "NetworKit::ApproxBetweenness" (_Centrality):

--- a/networkit/cpp/dynamics/GraphDifference.cpp
+++ b/networkit/cpp/dynamics/GraphDifference.cpp
@@ -1,0 +1,171 @@
+/*
+ *
+ */
+
+#include "GraphDifference.h"
+#include <string>
+
+namespace NetworKit {
+
+GraphDifference::GraphDifference(const Graph &G1, const Graph &G2) : G1(G1), G2(G2) {
+	if (G1.isDirected() != G2.isDirected()) {
+		throw std::runtime_error("Error, either both or none of the graphs must be directed.");
+	}
+
+	if (G1.isWeighted() != G2.isWeighted()) {
+		throw std::runtime_error("Error, either both or none of the graphs must be weighted.");
+	}
+}
+
+void GraphDifference::run() {
+	hasRun = false;
+	edits.clear();
+	numNodeAdditions = 0;
+	numNodeRemovals = 0;
+	numNodeRestorations = 0;
+	numEdgeAdditions = 0;
+	numEdgeRemovals = 0;
+	numWeightUpdates = 0;
+
+	std::vector<bool> marker(G1.upperNodeIdBound(), false);
+	std::vector<edgeweight> neighborWeights(G1.upperNodeIdBound(), 0);
+
+	// collect node events and edge removals/additions in separate vectors
+	// so we can later put them in the right order: first remove edges,
+	// then remove and add nodes and then add edges.
+	std::vector<GraphEvent> nodeEvents, edgeRemovals, edgeAdditions;
+
+	node updatedUpperNodeIdBound = G1.upperNodeIdBound();
+	for (node u = 0; u < G1.upperNodeIdBound() || u < G2.upperNodeIdBound(); ++u) {
+		// First, fix non-common nodes
+		if (!G2.hasNode(u) && G1.hasNode(u)) {
+			nodeEvents.emplace_back(GraphEvent::NODE_REMOVAL, u);
+			++numNodeRemovals;
+		} else if (G2.hasNode(u) && !G1.hasNode(u)) {
+			if (u < G1.upperNodeIdBound()) {
+				nodeEvents.emplace_back(GraphEvent::NODE_RESTORATION, u);
+				++numNodeRestorations;
+			} else {
+				while (u > updatedUpperNodeIdBound) {
+					// add and remove the same node immediately until we reach
+					// the desired node id.
+					nodeEvents.emplace_back(GraphEvent::NODE_ADDITION);
+					nodeEvents.emplace_back(GraphEvent::NODE_REMOVAL, updatedUpperNodeIdBound);
+					++updatedUpperNodeIdBound;
+				}
+
+				// add the actually wanted node.
+				nodeEvents.emplace_back(GraphEvent::NODE_ADDITION);
+				++updatedUpperNodeIdBound;
+				++numNodeAdditions;
+			}
+		}
+
+		// mark neighbors of current node in G1
+		if (G1.hasNode(u)) {
+			G1.forNeighborsOf(u, [&](node v, edgeweight w) {
+					if (G1.isDirected() || u <= v) {
+						TRACE("Marking neighbor of ", u, " in G1 ", v);
+						marker[v] = true;
+						neighborWeights[v] = w;
+					}
+				});
+		}
+
+		// unmark common neighbors, detect edge addtions
+		if (G2.hasNode(u)) {
+			G2.forNeighborsOf(u, [&](node v, edgeweight w) {
+					// for undirected graphs, edges are only added in one direction unless
+					// the other node does not exist in G1 (edges where both nodes do not
+					// exist in G1 have been added above).
+					if (G1.isDirected() || u <= v) {
+						if (v < G1.upperNodeIdBound() && marker[v]) {
+							if (neighborWeights[v] != w) {
+								edgeAdditions.emplace_back(GraphEvent::EDGE_WEIGHT_UPDATE, u, v, w);
+								++numWeightUpdates;
+							}
+							TRACE("Unmarking neighbor of ", u, " in G2 ", v);
+							marker[v] = false;
+						} else {
+							edgeAdditions.emplace_back(GraphEvent::EDGE_ADDITION, u, v, w);
+							++numEdgeAdditions;
+						}
+					}
+				});
+		}
+
+		if (G1.hasNode(u)) {
+			// detect edge removals, unset the remaining neighbor markers
+			G1.forNeighborsOf(u, [&](node v) {
+					TRACE("Checking again (", u, ",", v, ")");
+					if (G1.isDirected() || u <= v) {
+						TRACE("Edge (", u, ",", v, ") is considered");
+						if (marker[v]) {
+							TRACE("Deleting (", u, ",", v, ")");
+							edgeRemovals.emplace_back(GraphEvent::EDGE_REMOVAL, u, v);
+							++numEdgeRemovals;
+							marker[v] = false;
+						}
+					}
+				});
+		}
+	}
+
+	numEdits = numNodeRemovals + numNodeAdditions + numNodeRestorations + numEdgeRemovals + numEdgeAdditions + numWeightUpdates;
+
+	edits.swap(edgeRemovals);
+	edits.reserve(nodeEvents.size() + edgeAdditions.size());
+	edits.insert(edits.end(), nodeEvents.begin(), nodeEvents.end());
+	edits.insert(edits.end(), edgeAdditions.begin(), edgeAdditions.end());
+	hasRun = true;
+}
+
+std::vector< GraphEvent > GraphDifference::getEdits() const {
+	assureFinished();
+
+	return edits;
+}
+
+count GraphDifference::getNumberOfEdits() const {
+	assureFinished();
+
+	return numEdits;
+}
+
+count GraphDifference::getNumberOfNodeAdditions() const {
+	assureFinished();
+
+	return numNodeAdditions;
+}
+
+count GraphDifference::getNumberOfNodeRemovals() const {
+	assureFinished();
+
+	return numNodeRemovals;
+}
+
+count GraphDifference::getNumberOfNodeRestorations() const {
+	assureFinished();
+
+	return numNodeRestorations;
+}
+
+count GraphDifference::getNumberOfEdgeAdditions() const {
+	assureFinished();
+
+	return numEdgeAdditions;
+}
+
+count GraphDifference::getNumberOfEdgeRemovals() const {
+	assureFinished();
+
+	return numEdgeRemovals;
+}
+
+count GraphDifference::getNumberOfEdgeWeightUpdates() const {
+	assureFinished();
+
+	return numWeightUpdates;
+}
+
+}

--- a/networkit/cpp/dynamics/GraphDifference.h
+++ b/networkit/cpp/dynamics/GraphDifference.h
@@ -1,0 +1,109 @@
+#ifndef GRAPHDIFFERENCE_H
+#define GRAPHDIFFERENCE_H
+
+#include "../graph/Graph.h"
+#include "GraphEvent.h"
+#include "../base/Algorithm.h"
+
+namespace NetworKit {
+
+/**
+ * Calculate the edge difference between two graphs.
+ *
+ * This calculates which graph edge additions or edge removals are
+ * necessary to transform one given graph into another given graph.
+ *
+ * Both graphs need to have the same node set, directed graphs are not
+ * supported currently.
+ *
+ * Note that edge weight differences are not detected but edge
+ * addition events set the correct edge weight.
+ */
+class GraphDifference : public Algorithm {
+public:
+	/**
+	 * Construct the edge edit difference with two graphs to compare.
+	 *
+	 * @param G1 The first graph to compare.
+	 * @param G2 The second graph to compare.
+	 */
+	GraphDifference(const Graph &G1, const Graph &G2);
+
+	/**
+	 * Execute the algorithm and compute the difference.
+	 */
+	virtual void run() override;
+
+	/**
+	 * Get the required edits.
+	 *
+	 * @return A vector of graph events.
+	 */
+	std::vector<GraphEvent> getEdits() const;
+
+	/**
+	 * Get the required number of edits.
+	 *
+	 * This is only the number of actual changes.
+	 * In order to get correct node ids, more edits might be generated.
+	 *
+	 * @return The number of edits.
+	 */
+	count getNumberOfEdits() const;
+
+	/**
+	 * Get the required number of node addtions.
+	 *
+	 * @return The number of node additions.
+	 */
+	count getNumberOfNodeAdditions() const;
+
+	/**
+	 * Get the required number of node removals.
+	 *
+	 * @return The number of node removals.
+	 */
+	count getNumberOfNodeRemovals() const;
+
+	/**
+	 * Get the required number of node restorations.
+	 *
+	 * @return The number of node restorations.
+	 */
+	count getNumberOfNodeRestorations() const;
+
+	/**
+	 * Get the required number of edge addtions.
+	 *
+	 * @return The number of edge additions.
+	 */
+	count getNumberOfEdgeAdditions() const;
+
+	/**
+	 * Get the required number of edge removals.
+	 *
+	 * @return The number of edge removals.
+	 */
+	count getNumberOfEdgeRemovals() const;
+
+	/**
+	 * Get the required number of edge weight updates.
+	 *
+	 * @return The number of edge weight updates.
+	 */
+	count getNumberOfEdgeWeightUpdates() const;
+private:
+	const Graph &G1, &G2;
+	std::vector<GraphEvent> edits;
+	count numEdits;
+	count numNodeAdditions;
+	count numNodeRemovals;
+	count numNodeRestorations;
+	count numEdgeAdditions;
+	count numEdgeRemovals;
+	count numWeightUpdates;
+};
+
+} // namespace NetworKit
+
+#endif // GRAPHDIFFERENCE_H

--- a/networkit/cpp/dynamics/GraphEvent.cpp
+++ b/networkit/cpp/dynamics/GraphEvent.cpp
@@ -14,7 +14,7 @@ namespace NetworKit {
 GraphEvent::GraphEvent(GraphEvent::Type type, node u, node v, edgeweight w) : type(type), u(u), v(v), w(w) {
 }
 
-std::string GraphEvent::toString() {
+std::string GraphEvent::toString() const {
 	std::stringstream ss;
 	if (this->type == GraphEvent::NODE_ADDITION) {
 		ss << "an(" << u << ")";

--- a/networkit/cpp/dynamics/GraphEvent.h
+++ b/networkit/cpp/dynamics/GraphEvent.h
@@ -49,7 +49,7 @@ public:
 	/**
 	 * Return string representation.
 	 */
-	std::string toString();
+	std::string toString() const;
 
 };
 

--- a/networkit/cpp/dynamics/GraphUpdater.cpp
+++ b/networkit/cpp/dynamics/GraphUpdater.cpp
@@ -13,7 +13,7 @@ namespace NetworKit {
 GraphUpdater::GraphUpdater(Graph& G) : G(G) {
 }
 
-void GraphUpdater::update(std::vector<GraphEvent>& stream) {
+void GraphUpdater::update(const std::vector<GraphEvent>& stream) {
 	for (GraphEvent ev : stream) {
 		TRACE("event: " , ev.toString());
 		switch (ev.type) {

--- a/networkit/cpp/dynamics/GraphUpdater.h
+++ b/networkit/cpp/dynamics/GraphUpdater.h
@@ -22,7 +22,7 @@ public:
 
 	GraphUpdater(Graph& G);
 
-	void update(std::vector<GraphEvent>& stream);
+	void update(const std::vector<GraphEvent>& stream);
 
 	std::vector<std::pair<count, count> > getSizeTimeline();
 

--- a/networkit/dynamic.py
+++ b/networkit/dynamic.py
@@ -1,5 +1,5 @@
 # extension imports
-from _NetworKit import Graph, GraphEvent, DGSStreamParser, GraphUpdater, APSP
+from _NetworKit import Graph, GraphEvent, DGSStreamParser, GraphUpdater, APSP, GraphDifference
 
 
 def graphFromStream(stream, weighted, directed):


### PR DESCRIPTION
The GraphDifference algorithm computes a series of graph events that transform one given graph into another given graph. This makes it possible to construct a series of events from a given series of graphs.

Further, this marks `GraphEvent::toString()` as `const` and marks event stream passed to `GraphUpdater` as `const`.