### PR TITLE
Faster Partition::compact() implementation

### DIFF
--- a/networkit/cpp/structures/test/PartitionGTest.cpp
+++ b/networkit/cpp/structures/test/PartitionGTest.cpp
@@ -225,10 +225,22 @@ TEST_F(PartitionGTest, testCompact) {
 	EXPECT_EQ(5u, p.upperBound()); // This is only a weak test
 
 	// the following is a deeper test that checks if partition ids and structures match
-	std::vector<index> controlSet = {0,0,0,1,2,3,4,0,0,0};
-	p.forEntries([&](index e,index s){
-		EXPECT_EQ(controlSet[e],s);
-	});
+	EXPECT_EQ(p[0], p[1]);
+	EXPECT_EQ(p[0], p[2]);
+	EXPECT_NE(p[0], p[3]);
+	EXPECT_NE(p[0], p[4]);
+	EXPECT_NE(p[0], p[5]);
+	EXPECT_NE(p[0], p[6]);
+	EXPECT_NE(p[3], p[4]);
+	EXPECT_NE(p[3], p[5]);
+	EXPECT_NE(p[3], p[6]);
+	EXPECT_NE(p[4], p[5]);
+	EXPECT_NE(p[4], p[6]);
+	EXPECT_NE(p[5], p[6]);
+	EXPECT_NE(p[6], p[7]);
+	EXPECT_EQ(p[0], p[7]);
+	EXPECT_EQ(p[0], p[8]);
+	EXPECT_EQ(p[0], p[9]);
 }
 
 


### PR DESCRIPTION
This uses parallel sorting instead of a `std::map`. From a theoretical perspective, the total work is unchanged but while previously the sequential part was O(n log(n)), it is now only O(n) - a single sequential scan to determine unique ids.

`Partition::compact()` is the main bottleneck when comparing partitions using e.g. normalized mutual information or the adjusted rand index.

Apart from this optimization I also tried to simply replace the  `std::map` by a `std::unordered_map`. While this causes less total work than the implementation proposed in this PR, this implementation is faster  than the `std::unordered_map` variant when using multiple cores even on my laptop.