### PR TITLE
RFC: Faster graph readers for NetworKit

### DIFF
--- a/networkit/cpp/io/FastSNAPGraphReader.cpp
+++ b/networkit/cpp/io/FastSNAPGraphReader.cpp
@@ -1,0 +1,109 @@
+/*
+ * FastSNAPGraphReader.cpp
+ *
+ *  Created on: 04.05.2018
+ *      Author: Alexander van der Grinten
+ */
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "FastSNAPGraphReader.h"
+#include "../auxiliary/StringTools.h"
+#include "../auxiliary/Log.h"
+
+namespace NetworKit {
+
+Graph FastSNAPGraphReader::read(const std::string &path) {
+	Graph G;
+
+	// Maps SNAP node IDs to consecutive NetworKit node IDs.
+	auto mapNode = [&] (node in) -> node {
+		auto it = nodeIdMap.find(in);
+		if(it != nodeIdMap.end())
+			return it->second;
+		auto result = nodeIdMap.insert({in, G.addNode()});
+		assert(result.second);
+		return result.first->second;
+	};
+
+	// This function modifies the graph on input.
+	auto handleEdge = [&] (node source, node target) {
+		if(!G.hasEdge(source, target))
+			G.addEdge(source, target);
+	};
+	
+	auto fd = open(path.c_str(), O_RDONLY);
+	if(fd < 0)
+		throw std::runtime_error("Unable to open file");
+
+	struct stat st;
+	if(fstat(fd, &st))
+		throw std::runtime_error("Could not obtain file stats");
+
+	// It does not really matter if we use a private or shared mapping.
+	auto window = mmap(nullptr, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+	if(window == reinterpret_cast<void *>(-1))
+		throw std::runtime_error("Could not map file");
+	
+	if(close(fd))
+		throw std::runtime_error("Error during close()");
+
+	auto it = reinterpret_cast<char *>(window);
+	auto end = reinterpret_cast<char *>(window) + st.st_size;
+
+	// The following functions are helpers for parsing.
+	auto skipWhitespace = [&] {
+		while(it != end && (*it == ' ' || *it == '\t'))
+			++it;
+	};
+
+	auto scanId = [&] () -> node {
+		char *past;
+		auto value = strtol(it, &past, 10);
+		assert(past > it);
+		it = past;
+		return value;
+	};
+
+	// This loop does the actual parsing.
+	while(it != end) {
+		assert(it < end);
+
+		skipWhitespace();
+
+		assert(it != end);
+		if(*it == '\n') {
+			// We ignore empty lines.
+		}else if(*it == '#') {
+			// Skip non-linebreak characters.
+			while(it != end && *it != '\n')
+				++it;
+		}else{
+			auto sourceId = scanId();
+			assert(it != end);
+			assert(*it == ' ' || *it == '\t');
+			skipWhitespace();
+
+			auto targetId = scanId();
+			skipWhitespace();
+
+			handleEdge(mapNode(sourceId), mapNode(targetId));
+		}
+
+		assert(it != end);
+		assert(*it == '\n');
+		++it;
+	}
+
+	if(munmap(window, st.st_size))
+		throw std::runtime_error("Could not unmap file");
+
+	G.shrinkToFit();
+	return G;
+}
+
+} // namespace NetworKit
+

--- a/networkit/cpp/io/FastSNAPGraphReader.h
+++ b/networkit/cpp/io/FastSNAPGraphReader.h
@@ -1,0 +1,32 @@
+/*
+ * FastSNAPGraphReader.h
+ *
+ *  Created on: 04.05.2018
+ *      Author: Alexander van der Grinten
+ */
+#ifndef FASTSNAPGRAPHREADER_H_
+#define FASTSNAPGRAPHREADER_H_
+
+#include <unordered_map>
+
+#include "../graph/Graph.h"
+#include "GraphReader.h"
+
+namespace NetworKit {
+
+/**
+ * @ingroup io
+ */
+class FastSNAPGraphReader : public NetworKit::GraphReader {
+private:
+	std::unordered_map<node, node> nodeIdMap;
+
+public:
+	FastSNAPGraphReader() = default;
+
+	virtual Graph read(const std::string& path) override;
+};
+
+} /* namespace NetworKit */
+
+#endif /* FASTSNAPGRAPHREADER_H_ */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -22,6 +22,7 @@
 #include "../DGSReader.h"
 #include "../EdgeListWriter.h"
 #include "../EdgeListPartitionReader.h"
+#include "../FastSNAPGraphReader.h"
 #include "../SNAPEdgeListPartitionReader.h"
 #include "../SNAPGraphWriter.h"
 #include "../EdgeListReader.h"
@@ -513,6 +514,14 @@ TEST_F(IOGTest, tryReadingSNAP) {
 
 }
 
+TEST_F(IOGTest, testFastSNAPGraphReader) {
+	FastSNAPGraphReader reader;
+
+	Graph G = reader.read("input/comments.edgelist");
+
+	INFO("n = " , G.numberOfNodes());
+	INFO("m = " , G.numberOfEdges());
+}
 
 TEST_F(IOGTest, testSNAPGraphWriter) {
 	METISGraphReader reader;


### PR DESCRIPTION
Many of NetworKit's graph readers are quite slow. Reading very large graphs (billions of edges) can take hours of time. The reason for that is not so much the inherent I/O cost (which is also quite high) but the inefficient implementation of some graph readers in NetworKit.

For example, take a look at the SNAP and KONECT readers. The SNAP reader processes the entire input twice: Once to map SNAP node IDs to NetworKit IDs and once to retrieve the actual edges. During both passes, every line is loaded into a std::string and that string is split into a std::vector<std::string>. This approach requires at least 4 allocations *per line*. The KONECT reader is structured similarly. This PR (which is not intended to be merged as-is) tries to improve upon this situation.

Instead of using string classes to read lines, we mmap() the entire file at once and then only operate on characters, without requiring any allocations. Instead of performing two passes, we allocate node IDs on-the-fly.