### PR TITLE
Add various binary partition and graph readers and writers

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3403,6 +3403,43 @@ cdef class BinaryPartitionReader:
 	def read(self, path):
 		return Partition().setThis(self._this.read(stdstring(path)))
 
+cdef extern from "cpp/io/BinaryPartitionWriter.h":
+	cdef cppclass _BinaryPartitionWriter "NetworKit::BinaryPartitionWriter":
+		_BinaryPartitionWriter() except +
+		_BinaryPartitionWriter(uint8_t width) except +
+		_Partition write(_Partition zeta, string path) nogil except +
+
+cdef class BinaryPartitionWriter:
+	"""
+	Writes a partition to a file to contains a binary list of partition ids.
+	Partition ids are unsigned integers.
+
+	Parameters
+	----------
+	width : int
+		the width of the unsigned integer in bytes (4 or 8)
+
+	"""
+	cdef _BinaryPartitionWriter _this
+
+	def __cinit__(self, uint8_t width=4):
+		self._this = _BinaryPartitionWriter(width)
+
+	def write(self, Partition P not None, path):
+		"""
+		Write the partition to the given file.
+
+		Parameters
+		----------
+		path : str
+			The output path
+		"""
+		cdef string c_path = stdstring(path)
+
+		with nogil:
+			self._this.write(P._this, c_path)
+
+		return self
 
 cdef extern from "cpp/io/EdgeListPartitionReader.h":
 	cdef cppclass _EdgeListPartitionReader "NetworKit::EdgeListPartitionReader":

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3473,6 +3473,44 @@ cdef class BinaryEdgeListPartitionReader:
 
 		return Partition().setThis(result)
 
+cdef extern from "cpp/io/BinaryEdgeListPartitionWriter.h":
+	cdef cppclass _BinaryEdgeListPartitionWriter "NetworKit::BinaryEdgeListPartitionWriter":
+		_BinaryEdgeListPartitionWriter() except +
+		_BinaryEdgeListPartitionWriter(node firstNode, uint8_t width) except +
+		_Partition write(_Partition P, string path) nogil except +
+
+cdef class BinaryEdgeListPartitionWriter:
+	"""
+	Writes a partition file that contains a binary list of pairs (node, partition(node)).
+
+	Parameters
+	----------
+	firstNode : node
+		The id of the first node, this is added to all writen node ids
+	width : int
+		The width of the unsigned integer in bytes (4 or 8)
+	"""
+	cdef _BinaryEdgeListPartitionWriter _this
+
+	def __cinit__(self, node firstNode=0, uint8_t width=4):
+		self._this = _BinaryEdgeListPartitionWriter(firstNode, width)
+
+	def write(self, Partition P not None, path):
+		"""
+		Write the partition to the given file.
+
+		Parameters
+		----------
+		paths : str
+			The input path
+		"""
+		cdef string c_path = stdstring(path)
+
+		with nogil:
+			self._this.write(P._this, c_path)
+
+		return self
+
 cdef extern from "cpp/io/SNAPEdgeListPartitionReader.h":
 	cdef cppclass _SNAPEdgeListPartitionReader "NetworKit::SNAPEdgeListPartitionReader":
 		_SNAPEdgeListPartitionReader() except +

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3116,6 +3116,34 @@ cdef class ThrillGraphBinaryReader(GraphReader):
 
 		return Graph(0).setThis(result)
 
+cdef extern from "cpp/io/ThrillGraphBinaryWriter.h":
+	cdef cppclass _ThrillGraphBinaryWriter "NetworKit::ThrillGraphBinaryWriter":
+		void write(_Graph G, string path) nogil except +
+
+cdef class ThrillGraphBinaryWriter:
+	"""
+	Writes a graph format consisting of a serialized DIA of vector<uint32_t> from thrill.
+	Edges are written only in one direction.
+	"""
+
+	cdef _ThrillGraphBinaryWriter _this
+
+	"""
+	Write the graph to a binary file.
+
+	Parameters
+	----------
+	G     : Graph
+		The graph to write
+	paths : str
+		The output path
+	"""
+	def write(self, Graph G not None, path):
+		cdef string c_path = stdstring(path)
+		with nogil:
+			self._this.write(G._this, c_path)
+		return self
+
 cdef extern from "cpp/io/EdgeListReader.h":
 	cdef cppclass _EdgeListReader "NetworKit::EdgeListReader"(_GraphReader):
 		_EdgeListReader() except +

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -3538,8 +3538,8 @@ cdef class BinaryEdgeListPartitionWriter:
 
 		Parameters
 		----------
-		paths : str
-			The input path
+		path : str
+			The output path
 		"""
 		cdef string c_path = stdstring(path)
 

--- a/networkit/community.py
+++ b/networkit/community.py
@@ -7,7 +7,7 @@ from _NetworKit import Partition, Coverage, Modularity, CommunityDetector, PLP, 
 	NodeStructuralRandMeasure, GraphStructuralRandMeasure, JaccardMeasure, NMIDistance, AdjustedRandMeasure,\
 	StablePartitionNodes, IntrapartitionDensity, PartitionHubDominance, CoverHubDominance, PartitionFragmentation, IsolatedInterpartitionExpansion, IsolatedInterpartitionConductance,\
 	EdgeListPartitionReader, GraphClusteringTools, ClusteringGenerator, PartitionIntersection, HubDominance, CoreDecomposition, CutClustering, ParallelPartitionCoarsening, \
-	BinaryPartitionReader, BinaryEdgeListPartitionReader
+	BinaryPartitionReader, BinaryEdgeListPartitionReader, BinaryEdgeListPartitionWriter
 
 # R.I.P.: The CNM (Clauset, Newman, Moore) community detection algorithm - it was always a bit slow, but it broke down in the end. Resurrect it from history (<= 3.4.1) if needed for experimental purposes.
 

--- a/networkit/community.py
+++ b/networkit/community.py
@@ -6,7 +6,8 @@ __author__ = "Christian Staudt"
 from _NetworKit import Partition, Coverage, Modularity, CommunityDetector, PLP, LPDegreeOrdered, PLM, PartitionReader, PartitionWriter,\
 	NodeStructuralRandMeasure, GraphStructuralRandMeasure, JaccardMeasure, NMIDistance, AdjustedRandMeasure,\
 	StablePartitionNodes, IntrapartitionDensity, PartitionHubDominance, CoverHubDominance, PartitionFragmentation, IsolatedInterpartitionExpansion, IsolatedInterpartitionConductance,\
-	EdgeListPartitionReader, GraphClusteringTools, ClusteringGenerator, PartitionIntersection, HubDominance, CoreDecomposition, CutClustering, ParallelPartitionCoarsening
+	EdgeListPartitionReader, GraphClusteringTools, ClusteringGenerator, PartitionIntersection, HubDominance, CoreDecomposition, CutClustering, ParallelPartitionCoarsening, \
+	BinaryPartitionReader, BinaryEdgeListPartitionReader
 
 # R.I.P.: The CNM (Clauset, Newman, Moore) community detection algorithm - it was always a bit slow, but it broke down in the end. Resurrect it from history (<= 3.4.1) if needed for experimental purposes.
 

--- a/networkit/community.py
+++ b/networkit/community.py
@@ -7,7 +7,7 @@ from _NetworKit import Partition, Coverage, Modularity, CommunityDetector, PLP, 
 	NodeStructuralRandMeasure, GraphStructuralRandMeasure, JaccardMeasure, NMIDistance, AdjustedRandMeasure,\
 	StablePartitionNodes, IntrapartitionDensity, PartitionHubDominance, CoverHubDominance, PartitionFragmentation, IsolatedInterpartitionExpansion, IsolatedInterpartitionConductance,\
 	EdgeListPartitionReader, GraphClusteringTools, ClusteringGenerator, PartitionIntersection, HubDominance, CoreDecomposition, CutClustering, ParallelPartitionCoarsening, \
-	BinaryPartitionReader, BinaryEdgeListPartitionReader, BinaryEdgeListPartitionWriter
+	BinaryPartitionReader, BinaryPartitionWriter, BinaryEdgeListPartitionReader, BinaryEdgeListPartitionWriter
 
 # R.I.P.: The CNM (Clauset, Newman, Moore) community detection algorithm - it was always a bit slow, but it broke down in the end. Resurrect it from history (<= 3.4.1) if needed for experimental purposes.
 

--- a/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
@@ -1,0 +1,63 @@
+#include "BinaryEdgeListPartitionReader.h"
+#include <fstream>
+
+NetworKit::BinaryEdgeListPartitionReader::BinaryEdgeListPartitionReader(node firstNode, uint8_t width) : firstNode(firstNode), width(width) {
+	if (width != 4 && width != 8) {
+		throw std::runtime_error("Error: width must be 4 or 8");
+	}
+}
+
+namespace {
+
+	template <uint8_t width>
+	NetworKit::Partition readPartition(const std::string& path, NetworKit::node firstNode) {
+		using read_t = typename std::conditional<width == 4, uint32_t, uint64_t>::type;
+		static_assert(sizeof(read_t) == width, "Error, width is not the width of read_node_t");
+
+		std::ifstream is(path, std::ios_base::in | std::ios_base::binary);
+
+		if (!is) {
+			throw std::runtime_error("Error: partition file couldn't be opened");
+		}
+
+		is.seekg(0, std::ios_base::end);
+		NetworKit::count length = is.tellg() / (2 * width);
+		is.seekg(0);
+
+		NetworKit::Partition zeta(length);
+		
+		read_t u = 0, p = 0;
+
+		while (is.good()) {
+			is.read(reinterpret_cast<char*>(&u), width);
+			is.read(reinterpret_cast<char*>(&p), width);
+
+			if (u < firstNode) {
+				throw std::runtime_error("Error: node smaller than the given firstNode found!");
+			}
+
+			u -= firstNode;
+
+			if (p >= zeta.upperBound()) {
+				zeta.setUpperBound(p + 1);
+			}
+
+			while (u >= zeta.numberOfElements()) {
+				zeta.extend();
+			}
+
+			zeta[u] = p;
+		}
+
+		return zeta;
+	};
+};
+
+NetworKit::Partition NetworKit::BinaryEdgeListPartitionReader::read(const std::string& path) {
+	switch (width) {
+		case 4:
+			return readPartition<4>(path, firstNode);
+		default:
+			return readPartition<8>(path, firstNode);
+	};
+}

--- a/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
@@ -55,7 +55,7 @@ NetworKit::Partition NetworKit::BinaryEdgeListPartitionReader::read(const std::v
 
 			u -= firstNode;
 
-			if (p >= zeta.upperBound()) {
+			if (p != none && p >= zeta.upperBound()) {
 				zeta.setUpperBound(p + 1);
 			}
 

--- a/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
@@ -10,43 +10,56 @@ NetworKit::BinaryEdgeListPartitionReader::BinaryEdgeListPartitionReader(node fir
 namespace {
 
 	template <uint8_t width>
-	NetworKit::Partition readPartition(const std::string& path, NetworKit::node firstNode) {
+	NetworKit::Partition readPartition(const std::vector<std::string>& paths, NetworKit::node firstNode) {
 		using read_t = typename std::conditional<width == 4, uint32_t, uint64_t>::type;
 		static_assert(sizeof(read_t) == width, "Error, width is not the width of read_node_t");
 
-		std::ifstream is(path, std::ios_base::in | std::ios_base::binary);
+		NetworKit::Partition zeta(0);
 
-		if (!is) {
-			throw std::runtime_error("Error: partition file couldn't be opened");
-		}
+		if (!paths.empty()) {
+			std::ifstream is;
 
-		is.seekg(0, std::ios_base::end);
-		NetworKit::count length = is.tellg() / (2 * width);
-		is.seekg(0);
+			NetworKit::count _file_index = 0;
 
-		NetworKit::Partition zeta(length);
-		
-		read_t u = 0, p = 0;
+			auto next_input = [&]() {
+				is.close();
+				if (_file_index < paths.size()) {
+					is.open(paths[_file_index++], std::ios_base::in | std::ios_base::binary);
+					if (!is) {
+						throw std::runtime_error("Error: partition file couldn't be opened");
+					}
+				}
+			};
 
-		while (is.good()) {
-			is.read(reinterpret_cast<char*>(&u), width);
-			is.read(reinterpret_cast<char*>(&p), width);
+			next_input();
 
-			if (u < firstNode) {
-				throw std::runtime_error("Error: node smaller than the given firstNode found!");
+
+			read_t u = 0, p = 0;
+
+			while (is.good() && is.is_open()) {
+				is.read(reinterpret_cast<char*>(&u), width);
+				is.read(reinterpret_cast<char*>(&p), width);
+
+				if (u < firstNode) {
+					throw std::runtime_error("Error: node smaller than the given firstNode found!");
+				}
+
+				u -= firstNode;
+
+				if (p >= zeta.upperBound()) {
+					zeta.setUpperBound(p + 1);
+				}
+
+				while (u >= zeta.numberOfElements()) {
+					zeta.extend();
+				}
+
+				zeta[u] = p;
+
+				if (is.is_open() && (is.peek() == std::char_traits<char>::eof() || !is.good())) {
+					next_input();
+				}
 			}
-
-			u -= firstNode;
-
-			if (p >= zeta.upperBound()) {
-				zeta.setUpperBound(p + 1);
-			}
-
-			while (u >= zeta.numberOfElements()) {
-				zeta.extend();
-			}
-
-			zeta[u] = p;
 		}
 
 		return zeta;
@@ -56,8 +69,17 @@ namespace {
 NetworKit::Partition NetworKit::BinaryEdgeListPartitionReader::read(const std::string& path) {
 	switch (width) {
 		case 4:
-			return readPartition<4>(path, firstNode);
+			return readPartition<4>(std::vector<std::string>(1, path), firstNode);
 		default:
-			return readPartition<8>(path, firstNode);
+			return readPartition<8>(std::vector<std::string>(1, path), firstNode);
+	};
+}
+
+NetworKit::Partition NetworKit::BinaryEdgeListPartitionReader::read(const std::vector<std::string>& paths) {
+	switch (width) {
+		case 4:
+			return readPartition<4>(paths, firstNode);
+		default:
+			return readPartition<8>(paths, firstNode);
 	};
 }

--- a/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionReader.cpp
@@ -7,79 +7,77 @@ NetworKit::BinaryEdgeListPartitionReader::BinaryEdgeListPartitionReader(node fir
 	}
 }
 
-namespace {
-
-	template <uint8_t width>
-	NetworKit::Partition readPartition(const std::vector<std::string>& paths, NetworKit::node firstNode) {
-		using read_t = typename std::conditional<width == 4, uint32_t, uint64_t>::type;
-		static_assert(sizeof(read_t) == width, "Error, width is not the width of read_node_t");
-
-		NetworKit::Partition zeta(0);
-
-		if (!paths.empty()) {
-			std::ifstream is;
-
-			NetworKit::count _file_index = 0;
-
-			auto next_input = [&]() {
-				is.close();
-				if (_file_index < paths.size()) {
-					is.open(paths[_file_index++], std::ios_base::in | std::ios_base::binary);
-					if (!is) {
-						throw std::runtime_error("Error: partition file couldn't be opened");
-					}
-				}
-			};
-
-			next_input();
-
-
-			read_t u = 0, p = 0;
-
-			while (is.good() && is.is_open()) {
-				is.read(reinterpret_cast<char*>(&u), width);
-				is.read(reinterpret_cast<char*>(&p), width);
-
-				if (u < firstNode) {
-					throw std::runtime_error("Error: node smaller than the given firstNode found!");
-				}
-
-				u -= firstNode;
-
-				if (p >= zeta.upperBound()) {
-					zeta.setUpperBound(p + 1);
-				}
-
-				while (u >= zeta.numberOfElements()) {
-					zeta.extend();
-				}
-
-				zeta[u] = p;
-
-				if (is.is_open() && (is.peek() == std::char_traits<char>::eof() || !is.good())) {
-					next_input();
-				}
-			}
-		}
-
-		return zeta;
-	};
-};
-
 NetworKit::Partition NetworKit::BinaryEdgeListPartitionReader::read(const std::string& path) {
-	switch (width) {
-		case 4:
-			return readPartition<4>(std::vector<std::string>(1, path), firstNode);
-		default:
-			return readPartition<8>(std::vector<std::string>(1, path), firstNode);
-	};
+	return read(std::vector<std::string>(1, path));
 }
 
 NetworKit::Partition NetworKit::BinaryEdgeListPartitionReader::read(const std::vector<std::string>& paths) {
-	switch (width) {
-		case 4:
-			return readPartition<4>(paths, firstNode);
-		default:
-			return readPartition<8>(paths, firstNode);
-	};
+	Partition zeta(0);
+
+	if (!paths.empty()) {
+		std::ifstream is;
+
+		count file_index = 0;
+
+		auto next_input = [&]() {
+			is.close();
+			if (file_index < paths.size()) {
+				is.open(paths[file_index++], std::ios_base::in | std::ios_base::binary);
+				is.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+				if (!is) {
+					throw std::runtime_error("Error: partition file couldn't be opened");
+				}
+			}
+		};
+
+		auto read_little_endian = [](std::ifstream &is, uint8_t width) -> index {
+			index result = 0;
+			for (uint8_t i = 0; i < width; ++i) {
+				index t = is.get();
+				result |= (t << (i * 8));
+			}
+
+			return result;
+		};
+
+		next_input();
+
+
+		index read_values = 0;
+		while (is.good() && is.is_open()) {
+			index u = read_little_endian(is, width);
+			index p = read_little_endian(is, width);
+
+			if (u < firstNode) {
+				throw std::runtime_error("Error: node smaller than the given firstNode found!");
+			}
+
+			u -= firstNode;
+
+			if (p >= zeta.upperBound()) {
+				zeta.setUpperBound(p + 1);
+			}
+
+			while (u >= zeta.numberOfElements()) {
+				zeta.extend();
+			}
+
+			zeta[u] = p;
+
+			if (is.is_open() && (is.peek() == std::char_traits<char>::eof() || !is.good())) {
+				next_input();
+			}
+
+			++read_values;
+		}
+
+		if (read_values < zeta.numberOfElements()) {
+			throw std::runtime_error("Error, read less values than there are elements in the partition.");
+		} else if (read_values > zeta.numberOfElements()) {
+			throw std::runtime_error("Error, read more values than there are elements in the partition.");
+		}
+	}
+
+	return zeta;
 }

--- a/networkit/cpp/io/BinaryEdgeListPartitionReader.h
+++ b/networkit/cpp/io/BinaryEdgeListPartitionReader.h
@@ -1,0 +1,42 @@
+#ifndef BINARYEDGELISTPARTITION_H_
+#define BINARYEDGELISTPARTITION_H_
+
+#include "../structures/Partition.h"
+#include <string>
+
+namespace NetworKit {
+
+/**
+ * Reads a partition file that contains a binary list of pairs (node, partition(node)).
+ * It is assumed that all integers are unsigned.
+ *
+ * @ingroup io
+ */
+class BinaryEdgeListPartitionReader {
+
+public:
+
+	/**
+	 * Constructs the BinaryEdgeListPartitionReader class with @a firstNode as the id of the node that shall become node 0 and @a width the width of the integers read.
+	 * @param[in]	firstNode	Index of the first node in the file.
+	 * @param[in]	width		The width of the read integers (supported values: 4, 8)
+	 */
+	BinaryEdgeListPartitionReader(node firstNode=0, uint8_t width = 4);
+
+	/**
+	 * Read a partition from a file. File format:
+	 * 		binary list of pairs (node, partition(node))
+	 * Partition ids must be in the range [0, max(uint64_t)).
+	 *
+	 * @param[in]	path	Path to file.
+	 * @return The partition contained in the file at @a path.
+	 */
+	virtual Partition read(const std::string& path);
+
+
+	node firstNode;
+	uint8_t width;
+};
+
+} /* namespace NetworKit */
+#endif /* BINARYEDGELISTPARTITIONREADER_H_ */

--- a/networkit/cpp/io/BinaryEdgeListPartitionReader.h
+++ b/networkit/cpp/io/BinaryEdgeListPartitionReader.h
@@ -28,10 +28,11 @@ public:
 	 * 		binary list of pairs (node, partition(node))
 	 * Partition ids must be in the range [0, max(uint64_t)).
 	 *
-	 * @param[in]	path	Path to file.
+	 * @param[in]	path	Path to file or to several files (which are read in order).
 	 * @return The partition contained in the file at @a path.
 	 */
 	virtual Partition read(const std::string& path);
+	virtual Partition read(const std::vector<std::string>& paths);
 
 
 	node firstNode;

--- a/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
@@ -1,0 +1,36 @@
+#include "BinaryEdgeListPartitionWriter.h"
+#include <fstream>
+
+NetworKit::BinaryEdgeListPartitionWriter::BinaryEdgeListPartitionWriter(NetworKit::node firstNode, uint8_t width) : firstNode(firstNode), width(width) {
+	if (width != 4 && width != 8) {
+ 		throw std::runtime_error("Width must be 4 or 8");
+	}
+}
+
+namespace {
+	template <uint8_t width>
+	void writePartition(NetworKit::Partition &zeta, const std::string &path) {
+		using write_t = typename std::conditional<width == 4, uint32_t, uint64_t>::type;
+		static_assert(sizeof(write_t) == width, "write_t does not have the expected width");
+		
+		std::ofstream os(path, std::ios::trunc | std::ios::binary);
+		
+		zeta.forEntries([&](NetworKit::index u, NetworKit::index p) {
+				write_t uw = u;
+				write_t pw = p;
+				os.write(reinterpret_cast<const char*>(&uw), width);
+				os.write(reinterpret_cast<const char*>(&pw), width);
+		    });
+	}
+}
+
+void NetworKit::BinaryEdgeListPartitionWriter::write( NetworKit::Partition &zeta, const std::string &path ) const {
+	switch (width) {
+	case 4:
+		writePartition<4>(zeta, path);
+		break;
+	default:
+		writePartition<8>(zeta, path);
+		break;
+	}
+}

--- a/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
@@ -7,30 +7,24 @@ NetworKit::BinaryEdgeListPartitionWriter::BinaryEdgeListPartitionWriter(NetworKi
 	}
 }
 
-namespace {
-	template <uint8_t width>
-	void writePartition(NetworKit::node firstNode, NetworKit::Partition &zeta, const std::string &path) {
-		using write_t = typename std::conditional<width == 4, uint32_t, uint64_t>::type;
-		static_assert(sizeof(write_t) == width, "write_t does not have the expected width");
-		
-		std::ofstream os(path, std::ios::trunc | std::ios::binary);
-		
-		zeta.forEntries([&](NetworKit::index u, NetworKit::index p) {
-				write_t uw = u + firstNode;
-				write_t pw = p;
-				os.write(reinterpret_cast<const char*>(&uw), width);
-				os.write(reinterpret_cast<const char*>(&pw), width);
-		    });
-	}
-}
-
 void NetworKit::BinaryEdgeListPartitionWriter::write( NetworKit::Partition &zeta, const std::string &path ) const {
-	switch (width) {
-	case 4:
-		writePartition<4>(firstNode, zeta, path);
-		break;
-	default:
-		writePartition<8>(firstNode, zeta, path);
-		break;
+	auto write_little_endian = [](std::ofstream &os, index x, uint8_t width) {
+		for (uint8_t w = 0; w < width; ++w) {
+			os.put(uint8_t(x));
+			x >>= 8;
+		}
+	};
+
+	if (width == 4 && zeta.upperBound() > std::numeric_limits<uint32_t>::max()) {
+		throw std::runtime_error("Error, the upper bound of the given partition cannot be represented by an unsigned int of width 4. Please use a width of 8.");
 	}
+
+	std::ofstream os(path, std::ios::trunc | std::ios::binary);
+
+	os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+
+	zeta.forEntries([&](NetworKit::index u, NetworKit::index p) {
+		write_little_endian(os, u + firstNode, width);
+		write_little_endian(os, p, width);
+	});
 }

--- a/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
+++ b/networkit/cpp/io/BinaryEdgeListPartitionWriter.cpp
@@ -9,14 +9,14 @@ NetworKit::BinaryEdgeListPartitionWriter::BinaryEdgeListPartitionWriter(NetworKi
 
 namespace {
 	template <uint8_t width>
-	void writePartition(NetworKit::Partition &zeta, const std::string &path) {
+	void writePartition(NetworKit::node firstNode, NetworKit::Partition &zeta, const std::string &path) {
 		using write_t = typename std::conditional<width == 4, uint32_t, uint64_t>::type;
 		static_assert(sizeof(write_t) == width, "write_t does not have the expected width");
 		
 		std::ofstream os(path, std::ios::trunc | std::ios::binary);
 		
 		zeta.forEntries([&](NetworKit::index u, NetworKit::index p) {
-				write_t uw = u;
+				write_t uw = u + firstNode;
 				write_t pw = p;
 				os.write(reinterpret_cast<const char*>(&uw), width);
 				os.write(reinterpret_cast<const char*>(&pw), width);
@@ -27,10 +27,10 @@ namespace {
 void NetworKit::BinaryEdgeListPartitionWriter::write( NetworKit::Partition &zeta, const std::string &path ) const {
 	switch (width) {
 	case 4:
-		writePartition<4>(zeta, path);
+		writePartition<4>(firstNode, zeta, path);
 		break;
 	default:
-		writePartition<8>(zeta, path);
+		writePartition<8>(firstNode, zeta, path);
 		break;
 	}
 }

--- a/networkit/cpp/io/BinaryEdgeListPartitionWriter.h
+++ b/networkit/cpp/io/BinaryEdgeListPartitionWriter.h
@@ -1,0 +1,45 @@
+/**
+ * BinaryEdgeListPartitionWriter.h
+ *
+ * @author Michael Hamann <michael.hamann@kit.edu>
+ */
+
+#ifndef BINARYEDGELISTPARTITIONWRITER_H_
+#define BINARYEDGELISTPARTITIONWRITER_H_
+
+#include "../structures/Partition.h"
+#include <string>
+
+namespace NetworKit {
+
+/**
+ * @ingroup io
+ * Writes a partition to a file that contains a binary list of pairs (node, partition(node)).
+ * All integers are unsigned integers.
+ */
+class BinaryEdgeListPartitionWriter {
+public:
+	/**
+	 * Constructs the BinaryEdgeListPartitionWriter class with @a firstNode as the id of the
+	 * first node (i.e., this value is added to all node ids before writing) using unsigned
+	 * integers with the given @a width.
+	 *
+	 * @param[in] firstNode The id of node 0, all other node ids are adjusted accordingly.
+	 * @param[in] width The width of the written integers (supported values: 4, 8).
+	 */
+	BinaryEdgeListPartitionWriter(node firstNode = 0, uint8_t width = 4);
+	
+	/**
+	 * Write the given partition @a zeta to the given @a path.
+	 * 
+	 * @param[in] zeta The partition to write.
+         * @param[in] path The path to write to.
+	 */
+	virtual void write(Partition& zeta, const std::string& path) const;
+private:
+	node firstNode;
+	uint8_t width;
+};
+} /* namespace NetworKit */
+
+#endif /* BINARYEDGELISTPARTITIONWRITER_H_ */

--- a/networkit/cpp/io/BinaryPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryPartitionReader.cpp
@@ -35,7 +35,7 @@ NetworKit::Partition NetworKit::BinaryPartitionReader::read(const std::string& p
 				p |= (t << (i * 8));
 			}
 
-			if (p >= zeta.upperBound()) {
+			if (p != none && p >= zeta.upperBound()) {
 				zeta.setUpperBound(p + 1);
 			}
 

--- a/networkit/cpp/io/BinaryPartitionReader.cpp
+++ b/networkit/cpp/io/BinaryPartitionReader.cpp
@@ -1,0 +1,51 @@
+#include "BinaryPartitionReader.h"
+#include <fstream>
+
+
+NetworKit::BinaryPartitionReader::BinaryPartitionReader(uint8_t width) : width(width) {
+	if (width != 4 && width != 8) {
+		throw std::runtime_error("Only 4 and 8 are supported widths");
+	}
+}
+
+namespace {
+	template <uint8_t width>
+	NetworKit::Partition readPartition(const std::string& path) {
+		using read_t = typename std::conditional<width == 4, uint32_t, uint64_t>::type;
+		static_assert(sizeof(read_t) == width, "Error, width is not the width of read_node_t");
+
+		std::ifstream is(path, std::ios_base::in | std::ios_base::binary);
+
+		if (!is) {
+			throw std::runtime_error("Error: partition file couldn't be opened");
+		}
+
+		is.seekg(0, std::ios_base::end);
+		NetworKit::count length = is.tellg() / width;
+		is.seekg(0);
+
+		NetworKit::Partition zeta(length);
+		
+		read_t p = 0;
+		for (read_t u = 0; u < length; ++u) {
+			is.read(reinterpret_cast<char*>(&p), width);
+
+			if (p >= zeta.upperBound()) {
+				zeta.setUpperBound(p + 1);
+			}
+
+			zeta[u] = p;
+		}
+
+		return zeta;
+	};
+};
+
+NetworKit::Partition NetworKit::BinaryPartitionReader::read(const std::string& path) {
+	switch (width) {
+		case 4:
+			return readPartition<4>(path);
+		default:
+			return readPartition<8>(path);
+	};
+}

--- a/networkit/cpp/io/BinaryPartitionReader.h
+++ b/networkit/cpp/io/BinaryPartitionReader.h
@@ -1,0 +1,41 @@
+/*
+ * BinaryPartitionReader.h
+ *
+ *  Created on: 12.04.2017
+ *      Author: Michael Hamann <michael.hamann@kit.edu>
+ */
+
+#ifndef BINARYPARTITIONREADER_H_
+#define BINARYPARTITIONREADER_H_
+
+#include "../structures/Partition.h"
+
+namespace NetworKit {
+
+/**
+ * @ingroup io
+ */
+class BinaryPartitionReader {
+
+public:
+	/**
+	 * Construct a binary partition reader.
+	 *
+	 * @param[in]	width	The integer width. Supported values: 4 and 8.
+	 */
+	BinaryPartitionReader(uint8_t width = 4);
+	
+
+	/**
+	 * Read a partition from a file. File format:
+	 * 		list of (unsigned) integer partition ids, one for every node
+	 *
+	 * @param[in]	path	Path to file.
+	 */
+	virtual Partition read(const std::string& path);
+private:
+	uint8_t width;
+};
+
+} /* namespace NetworKit */
+#endif /* BINARYPARTITIONREADER_H_ */

--- a/networkit/cpp/io/BinaryPartitionWriter.cpp
+++ b/networkit/cpp/io/BinaryPartitionWriter.cpp
@@ -1,0 +1,29 @@
+#include "BinaryPartitionWriter.h"
+#include <fstream>
+
+NetworKit::BinaryPartitionWriter::BinaryPartitionWriter(uint8_t width) : width(width) {
+	if (width != 4 && width != 8) {
+		throw std::runtime_error("Only width 4 and 8 are supported");
+	}
+}
+
+void NetworKit::BinaryPartitionWriter::write(const Partition &zeta, const std::string &path) const {
+	if (width == 4 && zeta.upperBound() > std::numeric_limits<uint32_t>::max()) {
+		throw std::runtime_error("Error, the upper bound of the given partition cannot be represented by an unsigned int of width 4. Please use a width of 8.");
+	}
+
+	std::ofstream os(path, std::ios::trunc | std::ios::binary);
+
+	os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+
+	for (index i = 0; i < zeta.numberOfElements(); ++i) {
+		index p = zeta[i];
+
+		for (uint8_t w = 0; w < width; ++w) {
+			os.put(uint8_t(p));
+			p >>= 8;
+		}
+	}
+}
+
+

--- a/networkit/cpp/io/BinaryPartitionWriter.h
+++ b/networkit/cpp/io/BinaryPartitionWriter.h
@@ -1,0 +1,42 @@
+/**
+ * BinaryPartitionWriter.h
+ *
+ * @author Michael Hamann <michael.hamann@kit.edu>
+ */
+
+#ifndef BINARYPARTITIONWRITER_H_
+#define BINARYPARTITIONWRITER_H_
+
+#include "../structures/Partition.h"
+#include <string>
+
+namespace NetworKit {
+
+/**
+* @ingroup io
+* Writes a partition to a file to contains a binary list of partition ids.
+* Partition ids are unsigned integers.
+*/
+class BinaryPartitionWriter {
+public:
+	/**
+	 * Constructs the BinaryPartitionWriter class using unsigned integers
+	 * of width @a width for the written partition ids.
+	 *
+	 * @param[in] width The width of the written integers (supported values: 4, 8, default: 4).
+	 */
+	BinaryPartitionWriter(uint8_t width = 4);
+
+	/**
+	 * Write the given partition @a zeta to the given @a path.
+	 *
+	 * @param[in] zeta The partition to write.
+         * @param[in] path The path to write to.
+	 */
+	virtual void write(const Partition& zeta, const std::string& path) const;
+private:
+	uint8_t width;
+};
+}
+
+#endif

--- a/networkit/cpp/io/ThrillGraphBinaryReader.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryReader.cpp
@@ -48,12 +48,12 @@ NetworKit::Graph NetworKit::ThrillGraphBinaryReader::read(const std::vector<std:
 
 	if (!paths.empty()) {
 		std::ifstream is;
-		count _file_index = 0;
+		count file_index = 0;
 
 		auto next_input = [&]() {
 			is.close();
-			if (_file_index < paths.size()) {
-				is.open(paths[_file_index++]);
+			if (file_index < paths.size()) {
+				is.open(paths[file_index++]);
 			}
 		};
 

--- a/networkit/cpp/io/ThrillGraphBinaryReader.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryReader.cpp
@@ -1,5 +1,6 @@
 #include "ThrillGraphBinaryReader.h"
 #include "../graph/GraphBuilder.h"
+#include <algorithm>
 
 NetworKit::ThrillGraphBinaryReader::ThrillGraphBinaryReader(count n) : n(n) {};
 
@@ -59,6 +60,8 @@ NetworKit::Graph NetworKit::ThrillGraphBinaryReader::read(const std::vector<std:
 
 		next_input();
 
+		node max_id = 0;
+
 		for (node u = 0; is.good() && is.is_open(); ++u) {
 			// Add node if it does not exist yet, only one may be missing
 			if (u >= gb.upperNodeIdBound()) {
@@ -71,6 +74,8 @@ NetworKit::Graph NetworKit::ThrillGraphBinaryReader::read(const std::vector<std:
 					throw std::runtime_error("I/O error while reading next neighbor");
 				}
 
+				max_id = std::max<node>(max_id, v);
+
 				gb.addHalfEdge(u, v);
 			}
 
@@ -78,7 +83,11 @@ NetworKit::Graph NetworKit::ThrillGraphBinaryReader::read(const std::vector<std:
 				next_input();
 			}
 		}
+
+		if (max_id >= gb.upperNodeIdBound()) {
+			throw std::runtime_error("Maximum read node id larger than number of nodes read.");
+		}
 	}
-	
+
 	return gb.toGraph(true, true);
 };

--- a/networkit/cpp/io/ThrillGraphBinaryReader.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryReader.cpp
@@ -1,0 +1,84 @@
+#include "ThrillGraphBinaryReader.h"
+#include "../graph/GraphBuilder.h"
+
+NetworKit::ThrillGraphBinaryReader::ThrillGraphBinaryReader(count n) : n(n) {};
+
+namespace {
+	template <typename stream_t>
+	uint64_t GetVarint(stream_t &is) {
+		auto get_byte = [&is]() -> uint8_t {
+			uint8_t result;
+			is.read(reinterpret_cast<char*>(&result), 1);
+			return result;
+		};
+		uint64_t u, v = get_byte();
+		if (!(v & 0x80)) return v;
+		v &= 0x7F;
+		u = get_byte(), v |= (u & 0x7F) << 7;
+		if (!(u & 0x80)) return v;
+		u = get_byte(), v |= (u & 0x7F) << 14;
+		if (!(u & 0x80)) return v;
+		u = get_byte(), v |= (u & 0x7F) << 21;
+		if (!(u & 0x80)) return v;
+		u = get_byte(), v |= (u & 0x7F) << 28;
+		if (!(u & 0x80)) return v;
+		u = get_byte(), v |= (u & 0x7F) << 35;
+		if (!(u & 0x80)) return v;
+		u = get_byte(), v |= (u & 0x7F) << 42;
+		if (!(u & 0x80)) return v;
+		u = get_byte(), v |= (u & 0x7F) << 49;
+		if (!(u & 0x80)) return v;
+		u = get_byte(), v |= (u & 0x7F) << 56;
+		if (!(u & 0x80)) return v;
+		u = get_byte();
+		if (u & 0xFE)
+			throw std::overflow_error("Overflow during varint64 decoding.");
+		v |= (u & 0x7F) << 63;
+		return v;
+	}
+};
+
+
+NetworKit::Graph NetworKit::ThrillGraphBinaryReader::read(const std::string &path) {
+	return read(std::vector<std::string>(1, path));
+};
+
+NetworKit::Graph NetworKit::ThrillGraphBinaryReader::read(const std::vector<std::string> &paths) {
+	GraphBuilder gb(n);
+
+	if (!paths.empty()) {
+		std::ifstream is;
+		count _file_index = 0;
+
+		auto next_input = [&]() {
+			is.close();
+			if (_file_index < paths.size()) {
+				is.open(paths[_file_index++]);
+			}
+		};
+
+		next_input();
+
+		for (node u = 0; is.good() && is.is_open(); ++u) {
+			// Add node if it does not exist yet, only one may be missing
+			if (u >= gb.upperNodeIdBound()) {
+				gb.addNode();
+			}
+
+			for (count deg = GetVarint(is); deg > 0 && is.good(); --deg) {
+				uint32_t v;
+				if (!is.read(reinterpret_cast<char*>(&v), 4)) {
+					throw std::runtime_error("I/O error while reading next neighbor");
+				}
+
+				gb.addHalfEdge(u, v);
+			}
+
+			if (is.is_open() && (is.peek() == std::char_traits<char>::eof() || !is.good())) {
+				next_input();
+			}
+		}
+	}
+	
+	return gb.toGraph(true, true);
+};

--- a/networkit/cpp/io/ThrillGraphBinaryReader.h
+++ b/networkit/cpp/io/ThrillGraphBinaryReader.h
@@ -1,0 +1,47 @@
+
+/*
+ * ThrillGraphBinaryReader.h
+ *
+ * @author Michael Hamann <michael.hamann@kit.edu>
+ */
+
+#ifndef THRILLGRAPHBINARYREADER_H_
+#define THRILLGRAPHBINARYREADER_H_
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+
+#include "GraphReader.h"
+
+namespace NetworKit {
+
+/**
+ * Reads a graph format consisting of a serialized DIA of vector<uint32_t> from thrill.
+ */
+class ThrillGraphBinaryReader: public NetworKit::GraphReader {
+
+public:
+
+	/**
+	 * When the number of nodes is given, reading the graph is more efficient.
+	 *
+	 * @param[in]  n  The number of nodes
+	 */
+	ThrillGraphBinaryReader(count n = 0);
+
+	/**
+	 * Given the path of an input file, read the graph contained.
+	 *
+	 * @param[in]	path	input file path
+	 */
+	Graph read(const std::string& path) override;
+	Graph read(const std::vector<std::string>& path);
+private:
+	const count n;
+};
+
+} /* namespace NetworKit */
+#endif /* THRILLGRAPHBINARYREADER_H_ */

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
@@ -1,0 +1,115 @@
+#include "ThrillGraphBinaryWriter.h"
+
+namespace {
+    //! Append a varint to the writer.
+template <typename stream>
+stream& PutVarint(stream& s, uint64_t v) {
+	if (v < 128) {
+		s << uint8_t(v);
+	}
+	else if (v < 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t((v >> 07) & 0x7F);
+	}
+	else if (v < 128 * 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t((v >> 14) & 0x7F);
+	}
+	else if (v < 128 * 128 * 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
+		s << uint8_t((v >> 21) & 0x7F);
+	}
+	else if (v < 128llu * 128 * 128 * 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
+		s << uint8_t((v >> 28) & 0x7F);
+	}
+	else if (v < 128llu * 128 * 128 * 128 * 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
+		s << uint8_t((v >> 35) & 0x7F);
+	}
+	else if (v < 128llu * 128 * 128 * 128 * 128 * 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
+		s << uint8_t((v >> 42) & 0x7F);
+	}
+	else if (v < 128llu * 128 * 128 * 128 * 128 * 128 * 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 42) & 0x7F) | 0x80);
+		s << uint8_t((v >> 49) & 0x7F);
+	}
+	else if (v < 128llu * 128 * 128 * 128 * 128 * 128 * 128 * 128 * 128) {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 42) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 49) & 0x7F) | 0x80);
+		s << uint8_t((v >> 56) & 0x7F);
+	}
+	else {
+		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 42) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 49) & 0x7F) | 0x80);
+		s << uint8_t(((v >> 56) & 0x7F) | 0x80);
+		s << uint8_t((v >> 63) & 0x7F);
+	}
+
+	return s;
+};
+
+
+}
+
+
+void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const std::string &path ) {
+	if (G.numberOfNodes() > std::numeric_limits<uint32_t>::max()) {
+		throw std::runtime_error("Thrill binary graphs only support graphs with up to 2^32-1 nodes.");
+	}
+	
+	std::ofstream out_stream(path, std::ios::trunc | std::ios::binary);
+
+	std::vector<uint32_t> neighbors;
+	G.forNodes([&](node u) {
+			neighbors.clear();
+			G.forEdgesOf(u, [&](node v) {
+					if (u <= v) {
+						neighbors.push_back(v);
+					}
+			});
+
+			PutVarint(out_stream, neighbors.size());
+			
+			for (uint32_t v : neighbors) {
+				static_assert(std::is_same<uint32_t, decltype(v)>::value, "Node type is not uint32 anymore, adjust code!");
+				out_stream.write(reinterpret_cast<const char*>(&v), 4);
+			}
+	});
+
+	out_stream.close();
+}

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
@@ -28,7 +28,7 @@ void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const
 		}
 
 		while(deg) {
-			auto u = deg & 0x7F;
+			size_t u = deg & 0x7F;
 			deg >>= 7;
 			out_stream << uint8_t(u | (deg ? 0x80 : 0));
 		}
@@ -37,7 +37,7 @@ void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const
 			// write neighbor as little endian
 			for (size_t i = 0; i < sizeof(uint32_t); ++i) {
 				out_stream << uint8_t(v);
-				v >>= 7;
+				v >>= 8;
 			}
 		}
 	}

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
@@ -1,94 +1,7 @@
 #include "ThrillGraphBinaryWriter.h"
 
-namespace {
-    //! Append a varint to the writer.
-template <typename stream>
-stream& PutVarint(stream& s, uint64_t v) {
-	if (v < 128) {
-		s << uint8_t(v);
-	}
-	else if (v < 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t((v >> 07) & 0x7F);
-	}
-	else if (v < 128 * 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t((v >> 14) & 0x7F);
-	}
-	else if (v < 128 * 128 * 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
-		s << uint8_t((v >> 21) & 0x7F);
-	}
-	else if (v < 128llu * 128 * 128 * 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
-		s << uint8_t((v >> 28) & 0x7F);
-	}
-	else if (v < 128llu * 128 * 128 * 128 * 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
-		s << uint8_t((v >> 35) & 0x7F);
-	}
-	else if (v < 128llu * 128 * 128 * 128 * 128 * 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
-		s << uint8_t((v >> 42) & 0x7F);
-	}
-	else if (v < 128llu * 128 * 128 * 128 * 128 * 128 * 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 42) & 0x7F) | 0x80);
-		s << uint8_t((v >> 49) & 0x7F);
-	}
-	else if (v < 128llu * 128 * 128 * 128 * 128 * 128 * 128 * 128 * 128) {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 42) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 49) & 0x7F) | 0x80);
-		s << uint8_t((v >> 56) & 0x7F);
-	}
-	else {
-		s << uint8_t(((v >> 00) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 07) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 14) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 21) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 28) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 35) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 42) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 49) & 0x7F) | 0x80);
-		s << uint8_t(((v >> 56) & 0x7F) | 0x80);
-		s << uint8_t((v >> 63) & 0x7F);
-	}
-
-	return s;
-};
-
-
-}
-
-
 void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const std::string &path ) {
-	if (G.numberOfNodes() > std::numeric_limits<uint32_t>::max()) {
+	if (G.upperNodeIdBound() > std::numeric_limits<uint32_t>::max()) {
 		throw std::runtime_error("Thrill binary graphs only support graphs with up to 2^32-1 nodes.");
 	}
 	
@@ -103,11 +16,25 @@ void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const
 					}
 			});
 
-			PutVarint(out_stream, neighbors.size());
-			
+			size_t deg = neighbors.size();
+
+			// Write variable length int for the degree
+			if(!deg) {
+				out_stream << uint8_t(0);
+			}
+
+			while(deg) {
+				auto u = deg & 0x7F;
+				deg >>= 7;
+				out_stream << uint8_t(u | (deg ? 0x80 : 0));
+			}
+
 			for (uint32_t v : neighbors) {
-				static_assert(std::is_same<uint32_t, decltype(v)>::value, "Node type is not uint32 anymore, adjust code!");
-				out_stream.write(reinterpret_cast<const char*>(&v), 4);
+				// write neighbor as little endian
+				for (size_t i = 0; i < sizeof(uint32_t); ++i) {
+					out_stream << uint8_t(v);
+					v >>= 7;
+				}
 			}
 	});
 

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.cpp
@@ -8,35 +8,39 @@ void NetworKit::ThrillGraphBinaryWriter::write( const NetworKit::Graph &G, const
 	std::ofstream out_stream(path, std::ios::trunc | std::ios::binary);
 
 	std::vector<uint32_t> neighbors;
-	G.forNodes([&](node u) {
-			neighbors.clear();
+
+	for (node u = 0; u < G.upperNodeIdBound(); ++u) {
+		neighbors.clear();
+
+		if (G.hasNode(u)) {
 			G.forEdgesOf(u, [&](node v) {
-					if (u <= v) {
-						neighbors.push_back(v);
-					}
-			});
+						if (u <= v) {
+							neighbors.push_back(v);
+						}
+					});
+		}
 
-			size_t deg = neighbors.size();
+		size_t deg = neighbors.size();
 
-			// Write variable length int for the degree
-			if(!deg) {
-				out_stream << uint8_t(0);
+		// Write variable length int for the degree
+		if(!deg) {
+			out_stream << uint8_t(0);
+		}
+
+		while(deg) {
+			auto u = deg & 0x7F;
+			deg >>= 7;
+			out_stream << uint8_t(u | (deg ? 0x80 : 0));
+		}
+
+		for (uint32_t v : neighbors) {
+			// write neighbor as little endian
+			for (size_t i = 0; i < sizeof(uint32_t); ++i) {
+				out_stream << uint8_t(v);
+				v >>= 7;
 			}
-
-			while(deg) {
-				auto u = deg & 0x7F;
-				deg >>= 7;
-				out_stream << uint8_t(u | (deg ? 0x80 : 0));
-			}
-
-			for (uint32_t v : neighbors) {
-				// write neighbor as little endian
-				for (size_t i = 0; i < sizeof(uint32_t); ++i) {
-					out_stream << uint8_t(v);
-					v >>= 7;
-				}
-			}
-	});
+		}
+	}
 
 	out_stream.close();
 }

--- a/networkit/cpp/io/ThrillGraphBinaryWriter.h
+++ b/networkit/cpp/io/ThrillGraphBinaryWriter.h
@@ -1,0 +1,28 @@
+/*
+ * ThrillGraphBinaryWriter.h
+ *
+ * @author Michael Hamann <michael.hamann@kit.edu>
+ */
+
+#ifndef THRILLGRAPHBINARYWRITER_H_
+#define THRILLGRAPHBINARYWRITER_H_
+
+#include "GraphWriter.h"
+
+namespace NetworKit {
+
+class ThrillGraphBinaryWriter : public GraphWriter {
+public:
+	/**
+	 * Write the given graph into a binary file at the given path.
+	 * 
+	 * @param[in] G The graph to write.
+	 * @param[in] path The path where to write the graph.
+	 */
+	virtual void write(const Graph& G, const std::string& path);
+};
+
+} /* namespace NetworKit */
+
+
+#endif /* THRILLGRAPHBINARYWRITER_H_ */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -32,6 +32,8 @@
 #include "../GMLGraphReader.h"
 #include "../GraphToolBinaryReader.h"
 #include "../GraphToolBinaryWriter.h"
+#include "../ThrillGraphBinaryWriter.h"
+#include "../ThrillGraphBinaryReader.h"
 #include "../../generators/ErdosRenyiGenerator.h"
 
 #include "../../community/GraphClusteringTools.h"
@@ -40,6 +42,7 @@
 #include "../../structures/Partition.h"
 #include "../../community/Modularity.h"
 #include "../../community/PLP.h"
+#include "../../dynamics/GraphDifference.h"
 
 
 namespace NetworKit {
@@ -718,6 +721,34 @@ TEST_F(IOGTest, testGraphToolBinaryWriterWithDeletedNodesDirected) {
 	EXPECT_EQ(G.numberOfEdges(),Gread.numberOfEdges());
 	EXPECT_EQ(G.isDirected(),Gread.isDirected());
 	EXPECT_EQ(G.isWeighted(),Gread.isWeighted());
+}
+
+TEST_F(IOGTest, testThrillGraphBinaryWriterAndReader) {
+	// This test graph has a large maximum degree as degrees smaller than 128
+	// do not test the binary writer and reader properly.
+	// So we simply use a star.
+	count n = 257;
+	Graph G(n, false, false);
+	node center = 129;
+
+	for (node u = 0; u < n; ++u) {
+		if (u != center) {
+			G.addEdge(u, center);
+		}
+	}
+
+	std::string path = "output/test.thrillbin";
+
+	ThrillGraphBinaryReader reader;
+	ThrillGraphBinaryWriter writer;
+
+	writer.write(G, path);
+	Graph H = reader.read(path);
+
+	GraphDifference diff(G, H);
+	diff.run();
+
+	EXPECT_EQ(diff.getEdits().size(), 0);
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -34,6 +34,8 @@
 #include "../GraphToolBinaryWriter.h"
 #include "../ThrillGraphBinaryWriter.h"
 #include "../ThrillGraphBinaryReader.h"
+#include "../BinaryPartitionWriter.h"
+#include "../BinaryPartitionReader.h"
 #include "../../generators/ErdosRenyiGenerator.h"
 
 #include "../../community/GraphClusteringTools.h"
@@ -749,6 +751,30 @@ TEST_F(IOGTest, testThrillGraphBinaryWriterAndReader) {
 	diff.run();
 
 	EXPECT_EQ(diff.getEdits().size(), 0);
+}
+
+TEST_F(IOGTest, testBinaryPartitionWriterAndReader) {
+	Partition P(5);
+	P.setUpperBound((1ull<<32));
+	P[0] = 0;
+	P[1] = 2007;
+	P[2] = none;
+	P[3] = (1ull << 31 | 1ull << 28);
+	P[4] = 3925932491;
+
+	std::string path = "output/partition.bin";
+
+	BinaryPartitionWriter writer(8);
+	BinaryPartitionReader reader(8);
+
+	writer.write(P, path);
+	Partition Q(reader.read(path));
+
+	EXPECT_EQ(P[0], Q[0]);
+	EXPECT_EQ(P[1], Q[1]);
+	EXPECT_EQ(P[2], Q[2]);
+	EXPECT_EQ(P[3], Q[3]);
+	EXPECT_EQ(P[4], Q[4]);
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/io/test/IOGTest.cpp
+++ b/networkit/cpp/io/test/IOGTest.cpp
@@ -36,6 +36,8 @@
 #include "../ThrillGraphBinaryReader.h"
 #include "../BinaryPartitionWriter.h"
 #include "../BinaryPartitionReader.h"
+#include "../BinaryEdgeListPartitionWriter.h"
+#include "../BinaryEdgeListPartitionReader.h"
 #include "../../generators/ErdosRenyiGenerator.h"
 
 #include "../../community/GraphClusteringTools.h"
@@ -775,6 +777,32 @@ TEST_F(IOGTest, testBinaryPartitionWriterAndReader) {
 	EXPECT_EQ(P[2], Q[2]);
 	EXPECT_EQ(P[3], Q[3]);
 	EXPECT_EQ(P[4], Q[4]);
+	EXPECT_EQ(Q.upperBound(), P[4]+1);
+}
+
+TEST_F(IOGTest, testBinaryEdgeListPartitionWriterAndReader) {
+	Partition P(5);
+	P.setUpperBound((1ull<<32));
+	P[0] = 0;
+	P[1] = 2007;
+	P[2] = none;
+	P[3] = (1ull << 31 | 1ull << 28);
+	P[4] = 3925932491;
+
+	std::string path = "output/partition.bin";
+
+	BinaryEdgeListPartitionWriter writer(1, 8);
+	BinaryEdgeListPartitionReader reader(1, 8);
+
+	writer.write(P, path);
+	Partition Q(reader.read(path));
+
+	EXPECT_EQ(P[0], Q[0]);
+	EXPECT_EQ(P[1], Q[1]);
+	EXPECT_EQ(P[2], Q[2]);
+	EXPECT_EQ(P[3], Q[3]);
+	EXPECT_EQ(P[4], Q[4]);
+	EXPECT_EQ(Q.upperBound(), P[4]+1);
 }
 
 } /* namespace NetworKit */

--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -1,7 +1,7 @@
 # extension imports
 from _NetworKit import (METISGraphReader, METISGraphWriter, DotGraphWriter, EdgeListWriter, \
 						 GMLGraphWriter, LineFileReader, SNAPGraphWriter, DGSWriter, GraphToolBinaryWriter, GraphToolBinaryReader, \
-						  DGSStreamParser, GraphUpdater, SNAPEdgeListPartitionReader, SNAPGraphReader, EdgeListReader, CoverReader, CoverWriter, EdgeListCoverReader, KONECTGraphReader, GMLGraphReader)
+						  DGSStreamParser, GraphUpdater, SNAPEdgeListPartitionReader, SNAPGraphReader, EdgeListReader, CoverReader, CoverWriter, EdgeListCoverReader, KONECTGraphReader, GMLGraphReader, ThrillGraphBinaryReader)
 from _NetworKit import Graph as __Graph
 # local imports
 from .GraphMLIO import GraphMLReader, GraphMLWriter

--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -53,6 +53,7 @@ try:
 		KONECT = ()
 		GraphToolBinary = ()
 		MAT = ()
+		ThrillBinary = ()
 
 except ImportError:
 	print("Update to Python >=3.4 recommended - support for < 3.4 may be discontinued in the future")
@@ -74,6 +75,7 @@ except ImportError:
 		KONECT = "konect"
 		GraphToolBinary = "gtbin"
 		MAT = "mat"
+		ThrillBinary = "thrillbinary"
 
 
 
@@ -97,7 +99,8 @@ def getReader(fileformat, **kwargs):
 			Format.KONECT:			KONECTGraphReader(' '),
 			Format.GML:			GMLGraphReader(),
 			Format.GraphToolBinary:		GraphToolBinaryReader(),
-			Format.MAT:			MatReader()
+			Format.MAT:			MatReader(),
+			Format.ThrillBinary:		ThrillGraphBinaryReader(),
 			}
 
 	try:
@@ -118,7 +121,7 @@ def readGraph(path, fileformat, **kwargs):
 	    Parameters:
 		- fileformat: An element of the Format enumeration. Currently supported file types:
 		SNAP, EdgeListSpaceZero, EdgeListSpaceOne, EdgeListTabZero, EdgeListTabOne, METIS,
-		GraphML, GEXF, GML, EdgeListCommaOne, GraphViz, DOT, EdgeList, LFR, KONECT, GraphToolBinary
+		GraphML, GEXF, GML, EdgeListCommaOne, GraphViz, DOT, EdgeList, LFR, KONECT, GraphToolBinary, ThrillBinary
 		- **kwargs: in case of a custom edge list, pass the genereic Fromat.EdgeList accompanied by
 			the defining paramaters as follows:
 			"separator=CHAR, firstNode=NODE, commentPrefix=STRING, continuous=BOOL, directed=BOOL"

--- a/networkit/graphio.py
+++ b/networkit/graphio.py
@@ -1,7 +1,7 @@
 # extension imports
 from _NetworKit import (METISGraphReader, METISGraphWriter, DotGraphWriter, EdgeListWriter, \
 						 GMLGraphWriter, LineFileReader, SNAPGraphWriter, DGSWriter, GraphToolBinaryWriter, GraphToolBinaryReader, \
-						  DGSStreamParser, GraphUpdater, SNAPEdgeListPartitionReader, SNAPGraphReader, EdgeListReader, CoverReader, CoverWriter, EdgeListCoverReader, KONECTGraphReader, GMLGraphReader, ThrillGraphBinaryReader)
+						  DGSStreamParser, GraphUpdater, SNAPEdgeListPartitionReader, SNAPGraphReader, EdgeListReader, CoverReader, CoverWriter, EdgeListCoverReader, KONECTGraphReader, GMLGraphReader, ThrillGraphBinaryReader, ThrillGraphBinaryWriter)
 from _NetworKit import Graph as __Graph
 # local imports
 from .GraphMLIO import GraphMLReader, GraphMLWriter


### PR DESCRIPTION
This adds some readers and writers for binary graph and partition files. Basically, this is the code we used for the evaluation of our paper [Distributed Graph Clustering using Modularity and Map Equation](https://arxiv.org/abs/1710.09605) (code available at [kit-algo/distributed_clustering_thrill](https://github.com/kit-algo/distributed_clustering_thrill)). The [external memory LFR implementation](https://github.com/massive-graphs/extmem-lfr) supports the same formats, too.

The binary partition formats are straightforward generalizations of the standard partition formats, just using binary integers. In [Thrill](http://project-thrill.org/), this corresponds to a DIA of integers or pairs of integers. The graph format consists of one entry per node. Each node begins with its degree as variant and then the neighbors. The graph is undirected but neighbors are only stored in one direction. In Thrill this corresponds to a DIA of a `std::vector` of node ids. Due to this correspondence, unfortunately, no further metadata is supported. Currently, for graphs, only 32-bit node ids are implemented. As Thrill writes these files in parallel on multiple hosts, more than one input file is supported.

I can understand if you do not want to include these quite custom formats in NetworKit. Then, I would just continue maintaining a fork with them (and transform that into a separate module that can be built against NetworKit when separate Cython modules will be supported in NetworKit).