### PR TITLE
Reducing the runtime of the test suite

### DIFF
--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicPageRankGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicPageRankGTest.cpp
@@ -37,7 +37,7 @@ TEST(AlgebraicPageRankGTest, testPageRankDirected) {
 	EXPECT_EQ(pr_ranking[0].first, 699u);
 	EXPECT_NEAR(pr_ranking[0].second, 0.00432, tol);
 
-	t.start();
+	/*t.start();
 	PageRank pr(G);
 	t.stop();
 	INFO("Initilaizing graph-theoretic PageRank took ", t.elapsedMicroseconds() / 1000.0);
@@ -46,7 +46,7 @@ TEST(AlgebraicPageRankGTest, testPageRankDirected) {
 	pr.run();
 	t.stop();
 
-	INFO("Computing graph-theoretic page rank took ", t.elapsedMicroseconds() / 1000.0);
+	INFO("Computing graph-theoretic page rank took ", t.elapsedMicroseconds() / 1000.0);*/
 }
 
 TEST(AlgebraicPageRankGTest, testPageRankCentrality) {

--- a/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
+++ b/networkit/cpp/algebraic/algorithms/test/AlgebraicTriangleCountingGTest.cpp
@@ -10,7 +10,7 @@
 #include "../../CSRMatrix.h"
 #include "../AlgebraicTriangleCounting.h"
 #include "../../../auxiliary/Timer.h"
-#include "../../../io/SNAPGraphReader.h"
+#include "../../../io/METISGraphReader.h"
 #include "../../../centrality/LocalClusteringCoefficient.h"
 
 namespace NetworKit {
@@ -129,8 +129,8 @@ TEST(AlgebraicTriangleCountingGTest, testDirectedToyGraphThree) {
 }
 
 TEST(AlgebraicTriangleCountingGTest, testLocalClusteringCoefficient) {
-	SNAPGraphReader reader;
-	Graph graph = reader.read("input/wiki-Vote.txt");
+	METISGraphReader reader;
+	Graph graph = reader.read("input/celegans_metabolic.graph");
 	INFO("graph has ", graph.numberOfNodes(), " nodes and ", graph.numberOfEdges(), " edges and directed? ", graph.isDirected());
 
 	Aux::Timer timer;

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -499,7 +499,7 @@ TEST_F(CentralityGTest, testHarmonicClosenessCentrality) {
 
 TEST_F(CentralityGTest, testKPathCentrality) {
   METISGraphReader reader;
-  Graph G = reader.read("input/power.graph");
+  Graph G = reader.read("input/lesmis.graph");
 
   KPathCentrality centrality(G);
   centrality.run();

--- a/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynBetweennessGTest.cpp
@@ -40,7 +40,8 @@ TEST_F(DynBetweennessGTest, testDynApproxBetweennessSmallGraph) {
 	G.addEdge(5, 6);
 	G.addEdge(5, 7);
 
-	double epsilon = 0.01; // error
+	//double epsilon = 0.01; // error
+	double epsilon = 0.1; // error
 	double delta = 0.1; // confidence
 	DynApproxBetweenness dynbc(G, epsilon, delta);
 	Betweenness bc(G);
@@ -67,7 +68,8 @@ TEST_F(DynBetweennessGTest, testDynApproxBetweennessSmallGraph) {
 
 TEST_F(DynBetweennessGTest, testDynVsStatic) {
 	METISGraphReader reader;
-	Graph G = reader.read("input/PGPgiantcompo.graph");
+	//Graph G = reader.read("input/PGPgiantcompo.graph");
+	Graph G = reader.read("input/celegans_metabolic.graph");
 	count n = G.upperNodeIdBound();
 
 	double epsilon = 0.1; // error
@@ -120,8 +122,8 @@ TEST_F(DynBetweennessGTest, testDynVsStatic) {
 
 
 TEST_F(DynBetweennessGTest, testApproxBetweenness) {
-	METISGraphReader reader;
-	DorogovtsevMendesGenerator generator(1000);
+	//METISGraphReader reader;
+	DorogovtsevMendesGenerator generator(100);
 	Graph G1 = generator.generate();
 	Graph G(G1, true, false);
 	ApproxBetweenness bc(G, 0.1, 0.1);

--- a/networkit/cpp/centrality/test/DynTopHarmonicClosenessGTest.cpp
+++ b/networkit/cpp/centrality/test/DynTopHarmonicClosenessGTest.cpp
@@ -116,7 +116,7 @@ TEST_F(DynTopHarmonicClosenessGTest, testDynTopHarmonicClosenessUndirected) {
 TEST_F(DynTopHarmonicClosenessGTest, testDynTopHarmonicClosenessDirected) {
 
   Aux::Random::setSeed(42, false);
-  Graph G = ErdosRenyiGenerator(500, 0.1, true).generate();
+  Graph G = ErdosRenyiGenerator(300, 0.1, true).generate();
 
   count k = 10;
 

--- a/networkit/cpp/clique/test/CliqueGTest.cpp
+++ b/networkit/cpp/clique/test/CliqueGTest.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "CliqueGTest.h"
-#include "../MaxClique.h"
+#include "../MaximalCliques.h"
 #include "../../io/METISGraphReader.h"
 #include "../../io/SNAPGraphReader.h"
 #include "../../auxiliary/Log.h"
@@ -21,19 +21,20 @@ TEST_F(CliqueGTest, testMaxCliqueOnSmallerGraphs) {
 	Graph gJohnson = r.read("input/johnson8-4-4.edgelist");
 	Graph gHamming = r.read("input/hamming6-4.edgelist");
 
-	MaxClique mcJohnson(gJohnson);
-	MaxClique mcHamming(gHamming);
+	MaximalCliques mcJohnson(gJohnson,true);
+	MaximalCliques mcHamming(gHamming,true);
 
 	mcJohnson.run();
-	count maxCliqueSizeJohnson = mcJohnson.getMaxCliqueSize();
 	mcHamming.run();
-	count maxCliqueSizeHamming = mcHamming.getMaxCliqueSize();
+
+	std::vector<node> cliqueJohnson = mcJohnson.getCliques()[0];
+	count maxCliqueSizeJohnson = cliqueJohnson.size();
+	std::vector<node> cliqueHamming = mcHamming.getCliques()[0];
+	count maxCliqueSizeHamming = cliqueHamming.size();
 
 	EXPECT_EQ(14u,maxCliqueSizeJohnson) << "maximum clique size on graph johnson8-4-4 is not correct";
 	EXPECT_EQ(4u,maxCliqueSizeHamming) << "maximum clique size on graph hamming6-4 is not correct";
 
-	std::unordered_set<node> cliqueJohnson = mcJohnson.getMaxClique();
-	std::unordered_set<node> cliqueHamming = mcHamming.getMaxClique();
 	EXPECT_EQ(14u, cliqueJohnson.size());
 	EXPECT_EQ(4u, cliqueHamming.size());
 }

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -19,6 +19,7 @@
 #include "../../distance/Diameter.h"
 #include "../../io/METISGraphReader.h"
 #include "../../io/EdgeListReader.h"
+#include "../../io/KONECTGraphReader.h"
 #include "../../generators/HavelHakimiGenerator.h"
 #include "../../auxiliary/Log.h"
 #include "../../generators/DorogovtsevMendesGenerator.h"
@@ -74,8 +75,7 @@ namespace NetworKit {
 
     TEST_F(ConnectedComponentsGTest, testParallelConnectedComponents) {
         METISGraphReader reader;
-        std::vector<std::string> graphs = {"astro-ph", "PGPgiantcompo",
-        "caidaRouterLevel", "celegans_metabolic", "hep-th", "jazz"};
+        std::vector<std::string> graphs = {"PGPgiantcompo", "celegans_metabolic", "hep-th", "jazz"};
 
         for (auto graphName: graphs) {
             Graph G = reader.read("input/" + graphName + ".graph");
@@ -258,7 +258,7 @@ namespace NetworKit {
     TEST_F(ConnectedComponentsGTest, testDynConnectedComponents) {
         // construct graph
         METISGraphReader reader;
-        Graph G = reader.read("input/astro-ph.graph");
+        Graph G = reader.read("input/PGPgiantcompo.graph");
         DynConnectedComponents dccs(G);
         dccs.run();
         ConnectedComponents cc(G);
@@ -367,10 +367,10 @@ namespace NetworKit {
 
     TEST_F(ConnectedComponentsGTest, testWeaklyConnectedComponents) {
         // construct graph
-        EdgeListReader directReader('\t', 0, "#", false, true);
-        Graph G = directReader.read("input/MIT8.edgelist");
-        EdgeListReader undirectReader('\t', 0, "#", false, false);
-        Graph Gu = undirectReader.read("input/MIT8.edgelist");
+        EdgeListReader directReader(' ', 0, "%", false, true);
+        Graph G = directReader.read("input/johnson8-4-4.edgelist");
+        EdgeListReader undirectReader(' ', 0, "%", false, false);
+        Graph Gu = undirectReader.read("input/johnson8-4-4.edgelist");
         WeaklyConnectedComponents wc(G);
         ConnectedComponents cc(Gu);
         wc.run();
@@ -447,8 +447,8 @@ namespace NetworKit {
 
     TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponents) {
         // Read graph
-        EdgeListReader directReader('\t', 0, "#", false, true);
-        Graph G = directReader.read("input/MIT8.edgelist");
+		KONECTGraphReader reader(' ');
+		Graph G = reader.read("input/foodweb-baydry.konect");
         DynWeaklyConnectedComponents dw(G);
         dw.run();
         WeaklyConnectedComponents wc(G);

--- a/networkit/cpp/distance/test/CommuteTimeDistanceGTest.cpp
+++ b/networkit/cpp/distance/test/CommuteTimeDistanceGTest.cpp
@@ -94,7 +94,7 @@ TEST_F(CommuteTimeDistanceGTest, testOnWeightedToyGraph) {
 TEST_F(CommuteTimeDistanceGTest, testECTDOnSmallGraphs) {
 	METISGraphReader reader;
 
-	std::string graphFiles[2] = {"input/karate.graph", "input/tiny_01.graph"};
+	std::string graphFiles[1] = { "input/tiny_01.graph"};
 
 	for (auto graphFile: graphFiles) {
 		Graph G = reader.read(graphFile);
@@ -132,7 +132,7 @@ TEST_F(CommuteTimeDistanceGTest, testECTDOnSmallGraphs) {
 TEST_F(CommuteTimeDistanceGTest, testECTDParallelOnSmallGraphs) {
 	METISGraphReader reader;
 
-	std::string graphFiles[2] = {"input/karate.graph", "input/tiny_01.graph"};
+	std::string graphFiles[1] = { "input/tiny_01.graph"};
 
 	for (auto graphFile: graphFiles) {
 		Graph G = reader.read(graphFile);

--- a/networkit/cpp/distance/test/DistanceGTest.cpp
+++ b/networkit/cpp/distance/test/DistanceGTest.cpp
@@ -239,7 +239,7 @@ TEST_F(DistanceGTest, testEffectiveDiameterExact) {
 TEST_F(DistanceGTest, testHopPlotApproximation) {
 	using namespace std;
 
-	vector<string> testInstances= {"celegans_metabolic", "power", "lesmis"};
+	vector<string> testInstances= {"celegans_metabolic", "lesmis"};
 
 	const double tol = 1e-2;
 

--- a/networkit/cpp/distance/test/DynSSSPGTest.cpp
+++ b/networkit/cpp/distance/test/DynSSSPGTest.cpp
@@ -165,7 +165,7 @@ TEST_F(DynSSSPGTest, testDynamicDijkstra) {
 
 TEST_F(DynSSSPGTest, testDynamicBFSGeneratedGraph) {
 	METISGraphReader reader;
-	DorogovtsevMendesGenerator generator(1000);
+	DorogovtsevMendesGenerator generator(500);
 	Graph G = generator.generate();
 	DEBUG("Generated graph of dimension ", G.upperNodeIdBound());
 	DynBFS dyn_bfs(G, 0);
@@ -173,7 +173,7 @@ TEST_F(DynSSSPGTest, testDynamicBFSGeneratedGraph) {
 	dyn_bfs.run();
 	bfs.run();
 	DEBUG("Before the edge insertion: ");
-	count nInsertions = 1000, i = 0;
+	count nInsertions = 750, i = 0;
 	while (i < nInsertions) {
 		DEBUG("Sampling a new edge");
 		node v1 = Sampling::randomNode(G);

--- a/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
+++ b/networkit/cpp/generators/quadtree/test/QuadTreeGTest.cpp
@@ -395,7 +395,7 @@ TEST_F(QuadTreeGTest, testQuadTreeBalance) {
 }
 
 TEST_F(QuadTreeGTest, testSequentialQuadTreeConstruction) {
-	count n = 1000000;
+	count n = 100000;
 	count capacity = 1000;
 	double alpha = 1;
 	double R = HyperbolicSpace::hyperbolicAreaToRadius(n);
@@ -425,7 +425,7 @@ TEST_F(QuadTreeGTest, testSequentialQuadTreeConstruction) {
 
 TEST_F(QuadTreeGTest, testProbabilisticQuery) {
 	Aux::Random::setSeed(0, false);
-	count n = 10000;
+	count n = 5000;
 	count m = n*3;
 	count capacity = 20;
 	double R = 2*log(8*n / (M_PI*(m/n)*2));
@@ -525,7 +525,7 @@ TEST_F(QuadTreeGTest, testLeftSuppression) {
 	/**
 	 * define parameters
 	 */
-	count n = 100000;
+	count n = 10000;
 	double k = 10;
 	count m = n*k/2;
 	double targetR = HyperbolicSpace::getTargetRadius(n, m);

--- a/networkit/cpp/generators/test/GeneratorsGTest.cpp
+++ b/networkit/cpp/generators/test/GeneratorsGTest.cpp
@@ -136,8 +136,8 @@ TEST_F(GeneratorsGTest, viewDynamicBarabasiAlbertGenerator) {
 TEST_F(GeneratorsGTest, testStaticPubWebGenerator) {
 	Aux::Random::setSeed(42, false);
 
-	count n = 1800;
-	count numCluster = 24;
+	count n = 900;
+	count numCluster = 12;
 	count maxNumNeighbors = 36;
 	float rad = 0.075;
 
@@ -804,7 +804,7 @@ TEST_F(GeneratorsGTest, testHyperbolicPointGeneration) {
  */
 TEST_F(GeneratorsGTest, testHyperbolicGenerator) {
 	Aux::Random::setSeed(0, false);
-	count n = 100000;
+	count n = 10000;
 	double k = 32;
 	count m = k*n/2;
 	HyperbolicGenerator gen(n,k,7);
@@ -830,7 +830,7 @@ TEST_F(GeneratorsGTest, testHyperbolicGeneratorConsistency) {
 
 TEST_F(GeneratorsGTest, testHyperbolicGeneratorMechanicGraphs) {
 	Aux::Random::setSeed(0, false);
-	count n = 10000;
+	count n = 5000;
 	double k = 6;
 	count m = n*k/2;
 	HyperbolicGenerator gen(n, k, 3, 0.14);

--- a/networkit/cpp/geometric/test/GeometricGTest.cpp
+++ b/networkit/cpp/geometric/test/GeometricGTest.cpp
@@ -39,7 +39,7 @@ TEST_F(GeometricGTest, testConversion) {
  * Test numeric stability of Euclidean Circle conversion
  */
 TEST_F(GeometricGTest, testEuclideanCircleConsistency) {
-	const count n = 1000000;
+	const count n = 100000;
 	vector<double> angles(n);
 	vector<double> radii(n);
 	double stretch = 2;

--- a/networkit/cpp/numerics/test/LAMGGTest.h
+++ b/networkit/cpp/numerics/test/LAMGGTest.h
@@ -23,7 +23,7 @@ namespace NetworKit {
 
 class LAMGGTest : public testing::Test {
 protected:
-	const vector<string> GRAPH_INSTANCES = {"input/jazz.graph", "input/power.graph", "input/wing.graph"};
+	const vector<string> GRAPH_INSTANCES = {"input/jazz.graph", "input/power.graph"};
 
 	Vector randZeroSum(const Graph& graph, size_t seed) const;
 	Vector randVector(count dimension, double lower, double upper) const;


### PR DESCRIPTION
As discussed (#7 here too), this PR aims at reducing the testsuite runtime. #

As a start, I took the runtime on Travis and selected all tests with >1s (26 of 849 tests). 
All in all, most tests used too many or too great graphs for their algorithms complexity. With addressing these reasons I was able to reduce the runtime of the whole testsuite from 100s to 23s on my machine.

The first commit aims at improving the runtime of tests which are well written and which use gtest effectively. 

The tests improved in the second commit do NOT use gtest, while consuming a lot of runtime (longest test alone took 25s on travis). The runtime of these tests have been reduced drastically.