### PR TITLE
faster hasEdge() for undirected graphs

### DIFF
--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -745,8 +745,11 @@ void Graph::swapEdge(node s1, node t1, node s2, node t2) {
 bool Graph::hasEdge(node u, node v) const {
 	if (!directed && outDeg[u] > outDeg[v]){
 		return indexInOutEdgeArray(v, u) != none;
+	}else if (directed && outDeg[u] > inDeg[v]){
+		return indexInInEdgeArray(v, u) != none;
+	}else{
+		return indexInOutEdgeArray(u, v) != none;
 	}
-	return indexInOutEdgeArray(u, v) != none;
 }
 
 std::pair<node, node> Graph::randomEdge(bool uniformDistribution) const {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -743,6 +743,9 @@ void Graph::swapEdge(node s1, node t1, node s2, node t2) {
 }
 
 bool Graph::hasEdge(node u, node v) const {
+	if (!directed && outDeg[u] > outDeg[v]){
+		return indexInOutEdgeArray(v, u) != none;
+	}
 	return indexInOutEdgeArray(u, v) != none;
 }
 

--- a/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
+++ b/networkit/cpp/graph/test/GraphBuilderDirectSwapGTest.cpp
@@ -461,7 +461,7 @@ TEST_P(GraphBuilderDirectSwapGTest, testForValidStateAfterToGraph) {
 	node u = this->bHouse.addNode();
 	this->bHouse.addHalfOutEdge(v, u, 0.25);
 	if (isDirected()) {
-		this->bHouse.addHalfInEdge(v, u, 0.25);
+		this->bHouse.addHalfInEdge(u, v, 0.25);
 	} else {
 		this->bHouse.addHalfOutEdge(u, v, 0.25);
 	}


### PR DESCRIPTION
As proposed by @michitux here #160, i implemented a more efficient hasEdge function. There is no reason this feature should be limited to Graph Readers alone so i applied the changes to the Graph.cpp itself.

Nevertheless, the changes do not really speed up the performance of graph readers, but are efficient in other use cases - especially under power law conditions. For example the LFRGenerator uses the hasEdge method very extensively. I benchmarked the generation of a graph with power law degrees and recognized performance increases of around 10%.