### PR TITLE
Fix/fix module deps

### DIFF
--- a/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
+++ b/networkit/cpp/centrality/DynTopHarmonicCloseness.cpp
@@ -11,7 +11,7 @@
 #include "../auxiliary/PrioQueue.h"
 #include "../components/ConnectedComponents.h"
 #include "../components/StronglyConnectedComponents.h"
-#include "../dynamics/AffectedNodes.h"
+#include "../distance/AffectedNodes.h"
 #include "DynTopHarmonicCloseness.h"
 
 namespace NetworKit {

--- a/networkit/cpp/components/RandomSpanningForest.cpp
+++ b/networkit/cpp/components/RandomSpanningForest.cpp
@@ -5,9 +5,11 @@
  *      Author: Henning
  */
 
-#include "RandomSpanningForest.h"
 #include "../graph/Sampling.h"
-#include "../components/ConnectedComponents.h"
+
+#include "RandomSpanningForest.h"
+#include "ConnectedComponents.h"
+
 #include <unordered_set>
 
 namespace NetworKit {

--- a/networkit/cpp/components/RandomSpanningForest.h
+++ b/networkit/cpp/components/RandomSpanningForest.h
@@ -8,8 +8,8 @@
 #ifndef RANDOMSPANNINGFOREST_H_
 #define RANDOMSPANNINGFOREST_H_
 
-#include "Graph.h"
-#include "SpanningForest.h"
+#include "../graph/Graph.h"
+#include "../graph/SpanningForest.h"
 
 namespace NetworKit {
 

--- a/networkit/cpp/distance/AffectedNodes.cpp
+++ b/networkit/cpp/distance/AffectedNodes.cpp
@@ -6,9 +6,9 @@
  */
 
 #include "AffectedNodes.h"
-#include "../distance/BFS.h"
-#include "../distance/ReverseBFS.h"
-#include "../distance/SSSP.h"
+#include "BFS.h"
+#include "ReverseBFS.h"
+#include "SSSP.h"
 
 namespace NetworKit {
 

--- a/networkit/cpp/distance/AffectedNodes.h
+++ b/networkit/cpp/distance/AffectedNodes.h
@@ -10,7 +10,7 @@
 
 #include "../base/Algorithm.h"
 #include "../graph/Graph.h"
-#include "GraphEvent.h"
+#include "../dynamics/GraphEvent.h"
 
 namespace NetworKit {
 	

--- a/networkit/cpp/graph/test/SpanningGTest.cpp
+++ b/networkit/cpp/graph/test/SpanningGTest.cpp
@@ -7,7 +7,6 @@
 
 #include "SpanningGTest.h"
 #include "../KruskalMSF.h"
-#include "../RandomSpanningForest.h"
 #include "../SpanningForest.h"
 #include "../../io/METISGraphReader.h"
 
@@ -23,24 +22,6 @@ TEST_F(SpanningGTest, testKruskalMinSpanningForest) {
 		KruskalMSF msf(G);
 		msf.run();
 		Graph T = msf.getForest();
-
-		// check that each node has an edge in the spanning tree (if it had one before)
-		T.forNodes([&](node u) {
-			EXPECT_TRUE(T.degree(u) > 0 || G.degree(u) == 0);
-		});
-	}
-}
-
-TEST_F(SpanningGTest, testRandomSpanningTree) {
-	METISGraphReader reader;
-	std::vector<std::string> graphs = {"karate", "jazz", "celegans_metabolic"};
-
-	for (auto graphname: graphs) {
-		std::string filename = "input/" + graphname + ".graph";
-		Graph G = reader.read(filename);
-		RandomSpanningForest rst(G);
-		rst.run();
-		Graph T = rst.getForest();
 
 		// check that each node has an edge in the spanning tree (if it had one before)
 		T.forNodes([&](node u) {


### PR DESCRIPTION
This PR accompanies PR #154. 

It seems like we can realize NetworKit submodules with an acyclic (binary) dependency graph by moving only two classes, namely `graph/RandomSpanningForest` and `dynamics/AffectedNodes` to `components` and `distance` respectively.

All remaining dependencies are Header-only and hence do not prevent shared-libs.
