### PR TITLE
Improved ApproxGroupBetweenness.

### DIFF
--- a/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
@@ -70,7 +70,8 @@ void ApproxGroupBetweenness::run() {
 
 		// Insert the HyperEdge into hyperEdgePerSample
 		for (auto n : newHyperEdge) {
-			hyperEdgesPerSample[l].push_back(n);
+			if(n!=s && n!t)
+				hyperEdgesPerSample[l].push_back(n);
 		}
 	}
 


### PR DESCRIPTION
Improved the accuracy slightly,since we only need to add the internal nodes of the shortest paths to the hyperedge.