### PR TITLE
Improved ApproxGroupBetweenness.cpp

### DIFF
--- a/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
+++ b/networkit/cpp/centrality/ApproxGroupBetweenness.cpp
@@ -70,7 +70,8 @@ void ApproxGroupBetweenness::run() {
 
 		// Insert the HyperEdge into hyperEdgePerSample
 		for (auto n : newHyperEdge) {
-			hyperEdgesPerSample[l].push_back(n);
+			if(n != s && n != t)
+				hyperEdgesPerSample[l].push_back(n);
 		}
 	}
 


### PR DESCRIPTION
Slightly increased the accuracy, since we only need to add the internal nodes of a shortest path to the hyperedge.