### PR TITLE
Fix usage of EffectiveDiameterApproximation

### DIFF
--- a/benchmark/nk.py
+++ b/benchmark/nk.py
@@ -93,11 +93,11 @@ class bEffectiveDiameter(Algo):
 		return networkit.distance.EffectiveDiameter(G).run().getEffectiveDiameter()
 
 
-class bApproxEffectiveDiameter(Algo):
-	name = "ApproxEffectiveDiameter"
+class bEffectiveDiameterApproximation(Algo):
+	name = "EffectiveDiameterApproximation"
 
 	def run(self, G):
-		return networkit.distance.ApproxEffectiveDiameter(G).run().getEffectiveDiameter()
+		return networkit.distance.EffectiveDiameterApproximation(G).run().getEffectiveDiameter()
 
 
 class bApproxHopPlot(Algo):

--- a/networkit/profiling/profiling.py
+++ b/networkit/profiling/profiling.py
@@ -754,7 +754,7 @@ class Profile:
 			try:
 				timerInstance = stopwatch.Timer()
 				self.verbosePrint("EffectiveDiameter: ", end="")
-				diam = distance.ApproxEffectiveDiameter(self.__G)
+				diam = distance.EffectiveDiameterApproximation(self.__G)
 				diameter = diam.run().getEffectiveDiameter()
 				elapsedMain = timerInstance.elapsed
 				self.verbosePrint("{:.2F} s".format(elapsedMain))


### PR DESCRIPTION
Until now, measuring the approximated effective diameter in profiling always failed due to an incorrect function call.

This fixes #199.