### PR TITLE
Cumulative Updates to CMake-PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ script:
 
  - python3 -m venv pyenv && . pyenv/bin/activate
  - pip3 install --upgrade pip
+ - pip3 install ipython numpy scipy cython # jobs that conflict with --install-options
  - pip3 install --install-option="-j 2" -e . 
- - pip3 install ipython # required in networkit/profiling/profiling
  - python3 -m unittest discover -v networkit/test/
 
  - mkdir debug_test && cd "$_"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: generic
 
+env:
+  global:
+    - export OMP_NUM_THREADS=2
+    - export CXX_STANDARD=11
+
 matrix:
   include:
     - env: CC=gcc-4.9 CXX=g++-4.9
@@ -47,17 +52,46 @@ matrix:
         - export CPLUS_INCLUDE_PATH=$(llvm-config-3.7 --includedir)
         - export LIBRARY_PATH=$(llvm-config-3.7 --libdir)
 
+    - env: CC=gcc-8 CXX=g++-8
+      os: linux
+      addons: &gcc8
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+
+    - env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=14
+      os: linux
+      addons: *gcc8
+
+    - env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=17
+      os: linux
+      addons: *gcc8
+
 script:
  - echo $GTEST_LIB
  - echo $GTEST_INCLUDE
  - echo $OPENMP_LIB
  - echo $OPENMP_INCLUDE
  - $CXX --version
- - mkdir build_test && cd "$_"
- - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ..
+
+ - mkdir debug_test && cd "$_"
+ - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
  - make -j2
- - export OMP_NUM_THREADS=2
  - ctest -V
+ - cd .. && rm -rf debug_test
+
+ - mkdir release_test && cd "$_"
+ - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
+ - make -j2
+ - ctest -V
+ - cd .. && rm -rf release_test
+
+ - mkdir build_non_monolith && cd "$_"
+ - cmake -DNETWORKIT_MONOLITH=OFF -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
+ - make -j2
+ - cd .. && rm -rf build_non_monolith
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ script:
 
  - python3 -m venv pyenv && . pyenv/bin/activate
  - pip3 install --upgrade pip
- - pip3 install ipython numpy scipy cython # jobs that conflict with --install-options
- - pip3 install --install-option="-j 2" -e . 
+ - NETWORKIT_PARALLEL_JOBS=2 pip3 install -e . 
+ - pip3 install ipython # required for tests
  - python3 -m unittest discover -v networkit/test/
 
  - mkdir debug_test && cd "$_"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
             - cmake
             - g++-4.9
             - python3-pip
+            - python3.4-venv
 
     - env: CC=gcc-6 CXX=g++-6
       os: osx
@@ -39,6 +40,7 @@ matrix:
             - clang-3.8
             - libiomp-dev
             - python3-pip
+            - python3.4-venv
 
     - env: CC=clang-3.7 CXX=clang++-3.7
       os: osx
@@ -62,7 +64,7 @@ matrix:
           packages:
             - g++-8
             - python3-pip
-            - python3-venv
+            - python3.4-venv
 
     - env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=14
       os: linux
@@ -80,7 +82,6 @@ script:
  - $CXX --version
  - python3 --version
 
- - pip3 install --user virtualenv
  - python3 -m venv pyenv && . pyenv/bin/activate
  - pip3 install --upgrade pip
  - pip3 install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,7 @@ script:
  - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ..
  - make -j2
  - export OMP_NUM_THREADS=2
- - ./networkit_tests -t
- - ./networkit_tests -r
+ - ctest -V
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
           packages:
             - cmake
             - g++-4.9
-            - python-configparser
+            - python3-pip
 
     - env: CC=gcc-6 CXX=g++-6
       os: osx
@@ -26,6 +26,7 @@ matrix:
         - brew update
         - brew cask uninstall --force oclint # See https://github.com/travis-ci/travis-ci/issues/8826 for details.
         - brew install gcc@6
+        - brew upgrade python
 
     - env: CC="clang-3.8" CXX="clang++-3.8"
       os: linux
@@ -37,7 +38,7 @@ matrix:
           packages:
             - clang-3.8
             - libiomp-dev
-            - python-configparser
+            - python3-pip
 
     - env: CC=clang-3.7 CXX=clang++-3.7
       os: osx
@@ -46,7 +47,7 @@ matrix:
         - brew update
         - brew install llvm37
         - brew install libomp
-        - pip2 install configparser
+        - brew upgrade python
       install:
         - export C_INCLUDE_PATH=$(llvm-config-3.7 --includedir)
         - export CPLUS_INCLUDE_PATH=$(llvm-config-3.7 --includedir)
@@ -60,6 +61,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-8
+            - python3-pip
+            - python3-venv
 
     - env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=14
       os: linux
@@ -75,6 +78,14 @@ script:
  - echo $OPENMP_LIB
  - echo $OPENMP_INCLUDE
  - $CXX --version
+ - python3 --version
+
+ - pip3 install --user virtualenv
+ - python3 -m venv pyenv && . pyenv/bin/activate
+ - pip3 install --upgrade pip
+ - pip3 install -e .
+ - pip3 install ipython # required in networkit/profiling/profiling
+ - python3 -m unittest discover -v networkit/test/
 
  - mkdir debug_test && cd "$_"
  - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
 
  - python3 -m venv pyenv && . pyenv/bin/activate
  - pip3 install --upgrade pip
- - pip3 install -e .
+ - pip3 install --install-option="-j 2" -e . 
  - pip3 install ipython # required in networkit/profiling/profiling
  - python3 -m unittest discover -v networkit/test/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,6 @@ matrix:
       addons: *gcc8
 
 script:
- - echo $GTEST_LIB
- - echo $GTEST_INCLUDE
- - echo $OPENMP_LIB
- - echo $OPENMP_INCLUDE
  - $CXX --version
  - python3 --version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ option(NETWORKIT_INCLUDESYMLINK "Create symlink to cpp directory" ON)
 set(NETWORKIT_PYTHON "" CACHE STRING "Directory containing Python.h. Implies MONOLITH=TRUE")
 set(NETWORKIT_PYTHON_SOABI "" CACHE STRING "Platform specific file extension. Implies MONOLITH=TRUE")
 
+set( NETWORKIT_CXX_STANDARD "11" CACHE STRING "CXX Version to compile with. Currently fixed to 11")
+
 if (NETWORKIT_PYTHON)
 	if (NOT NETWORKIT_MONOLITH)
 		message(FATAL_ERROR "When building NetworKit as a Python module, NETWORKIT_MONOLITH=ON is required")
@@ -32,6 +34,7 @@ endif()
 ################################################################################
 # Compilation Flags
 set(NETWORKIT_CXX_FLAGS "")
+set(NETWORKIT_LINK_FLAGS "")
 
 if (NOT NETWORKIT_LOGGING)
 	set(NETWORKIT_CXX_FLAGS "-DNOLOGGING")
@@ -51,7 +54,9 @@ endif()
 find_package(OpenMP REQUIRED)
 if(OPENMP_FOUND)
 	link_directories("${OPENMP_LIBRARIES}")
+
 	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+	set(NETWORKIT_LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 else()
 	message(FATAL_ERROR "OpenMP not found")
 endif()
@@ -72,9 +77,9 @@ endif()
 if (NETWORKIT_MONOLITH)
 	add_library(networkit SHARED networkit/cpp/networkit.cpp)
 	set_target_properties(networkit PROPERTIES
-			CXX_STANDARD 11
+			CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
 			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
-			LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+			LINK_FLAGS "${NETWORKIT_LINK_FLAGS}")
 	if(APPLE)
 		set_target_properties(networkit PROPERTIES
 				LINK_FLAGS "-undefined dynamic_lookup")
@@ -86,9 +91,9 @@ if (NETWORKIT_MONOLITH)
 			target_link_libraries(_NetworKit PRIVATE networkit)
 			target_include_directories(_NetworKit PRIVATE "${NETWORKIT_PYTHON}")
 			set_target_properties(_NetworKit PROPERTIES
-						CXX_STANDARD 11
+						CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
 						COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
-						LINK_FLAGS "${OpenMP_CXX_FLAGS}"
+						LINK_FLAGS "${NETWORKIT_LINK_FLAGS}"
 						PREFIX ""
 						OUTPUT_NAME "_NetworKit.${NETWORKIT_PYTHON_SOABI}")
 			if(APPLE)
@@ -116,8 +121,9 @@ function(networkit_add_module modname)
 					${PROJECT_SOURCE_DIR}/networkit/cpp/networkit.cpp)
 
 		set_target_properties(${MODULE_TARGET} PROPERTIES
-			CXX_STANDARD 11
-			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}")
+			CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
+			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
+			LINK_FLAGS "${NETWORKIT_LINK_FLAGS}")
 
 		# All tests added to this module will will also become a dependency
 		# of networkit_tests_MODNAME. This target hence allows to build all
@@ -190,9 +196,9 @@ if (NETWORKIT_BUILD_TESTS)
 				networkit
 		)
 		set_target_properties(networkit_tests PROPERTIES
-			CXX_STANDARD 11
+			CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
 			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
-			LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+			LINK_FLAGS "${NETWORKIT_LINK_FLAGS}")
 
 		add_test(networkit_tests networkit_tests)
 		if(UNIX)
@@ -234,9 +240,9 @@ function(networkit_add_extra IS_TEST MOD NAME)
 					networkit_${MOD}
 				)
 			set_target_properties(${TARGET_NAME} PROPERTIES
-				CXX_STANDARD 11
+				CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
 				COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
-				LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+				LINK_FLAGS "${NETWORKIT_LINK_FLAGS}")
 
 			foreach(dep IN LISTS ARGN)
 				target_link_libraries(${TARGET_NAME} PRIVATE networkit_${dep})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,14 +200,19 @@ if (NETWORKIT_BUILD_TESTS)
 			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
 			LINK_FLAGS "${NETWORKIT_LINK_FLAGS}")
 
-		add_test(networkit_tests networkit_tests)
-		if(UNIX)
-			add_custom_target(symlink_input_folder ALL COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}/input" "input")
-			add_custom_target(symlink_output_folder ALL COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}/output" "output")
-		else()
-			message(WARNING "Cannot create input and output symlinks on a windows machine")
-		endif()
-		endif()
+		add_test(
+			NAME networkit_tests
+			COMMAND networkit_tests -t
+			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+		)
+
+		add_test(
+			NAME networkit_tests_no_assertions
+			COMMAND networkit_tests -r
+			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+		)
+
+	endif()
 endif()
 
 # internal use only

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if (NETWORKIT_PYTHON)
 		message(FATAL_ERROR "When building NetworKit as a Python module, NETWORKIT_MONOLITH=ON is required")
 	endif()
 	if(NOT NETWORKIT_PYTHON_SOABI)
-		message(WARNING "No Platform specific file extension provided. Do not distribute library.")
+		message(WARNING "No platform-specific file extension provided. Do not distribute library.")
 	endif()
 endif()
 

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -5499,9 +5499,6 @@ cdef class ConnectedComponents(Algorithm):
 		self._G = G
 		self._this = new _ConnectedComponents(G._this)
 
-	def __dealloc__(self):
-		del self._this
-
 	def getPartition(self):
 		""" Get a Partition that represents the components.
 
@@ -5551,9 +5548,6 @@ cdef class ParallelConnectedComponents(Algorithm):
 	def __cinit__(self,  Graph G, coarsening=True	):
 		self._G = G
 		self._this = new _ParallelConnectedComponents(G._this, coarsening)
-
-	def __dealloc__(self):
-		del self._this
 
 	def run(self):
 		with nogil:
@@ -5652,9 +5646,6 @@ cdef class WeaklyConnectedComponents(Algorithm):
 		self._G = G
 		self._this = new _WeaklyConnectedComponents(G._this)
 
-	def __dealloc__(self):
-		del self._this
-
 	def numberOfComponents(self):
 		""" Returns the number of components.
 
@@ -5717,9 +5708,6 @@ cdef class BiconnectedComponents(Algorithm):
 		self._G = G
 		self._this = new _BiconnectedComponents(G._this)
 
-	def __dealloc__(self):
-		del self._this
-
 	def numberOfComponents(self):
 		""" Returns the number of components.
 
@@ -5771,9 +5759,6 @@ cdef class DynConnectedComponents(Algorithm):
 	def __cinit__(self, Graph G):
 		self._G = G
 		self._this = new _DynConnectedComponents(G._this)
-
-	def __dealloc__(self):
-		del self._this
 
 	def numberOfComponents(self):
 		""" Returns the number of components.
@@ -5862,9 +5847,6 @@ cdef class DynWeaklyConnectedComponents(Algorithm):
 	def __cinit__(self, Graph G):
 		self._G = G
 		self._this = new _DynWeaklyConnectedComponents(G._this)
-
-	def __dealloc__(self):
-		del self._this
 
 	def numberOfComponents(self):
 		""" Returns the number of components.
@@ -6438,9 +6420,6 @@ cdef class TopCloseness(Algorithm):
 		self._G = G
 		self._this = new _TopCloseness(G._this, k, first_heu, sec_heu)
 
-	def __dealloc__(self):
-		del self._this
-
 	def topkNodesList(self, includeTrail=False):
 		""" Returns a list with the k nodes with highest closeness.
 			WARNING: closeness centrality of some nodes below the top-k could be equal
@@ -6513,9 +6492,6 @@ cdef class TopHarmonicCloseness(Algorithm):
 		self._G = G
 		self._this = new _TopHarmonicCloseness(G._this, k, useBFSbound)
 
-	def __dealloc__(self):
-		del self._this
-
 	def topkNodesList(self, includeTrail=False):
 		""" Returns a list with the k nodes with highest harmonic closeness.
 			WARNING: closeness centrality of some nodes below the top-k could be equal
@@ -6572,9 +6548,6 @@ cdef class DynKatzCentrality(Centrality):
 		self._G = G
 		self._this = new _DynKatzCentrality(G._this, k, groupOnly, tolerance)
 
-	def __dealloc__(self):
-		del self._this
-
 	def update(self, ev):
 		(<_DynKatzCentrality*>(self._this)).update(_GraphEvent(ev.type, ev.u, ev.v, ev.w))
 
@@ -6625,9 +6598,6 @@ cdef class DynTopHarmonicCloseness(Algorithm):
 	def __cinit__(self,  Graph G, k=1, useBFSbound=False):
 		self._G = G
 		self._this = new _DynTopHarmonicCloseness(G._this, k, useBFSbound)
-
-	def __dealloc__(self):
-		del self._this
 
 	def ranking(self, includeTrail = False):
 		""" Returns the ranking of the k most central nodes in the graph.
@@ -6742,9 +6712,6 @@ cdef class GroupDegree(Algorithm):
 		self._G = G
 		self._this = new _GroupDegree(G._this, k, countGroupNodes)
 
-	def __dealloc__(self):
-		del self._this
-
 	def groupMaxDegree(self):
 		"""
 		Returns the group with maximum degree centrality.
@@ -6796,9 +6763,6 @@ cdef class GroupCloseness(Algorithm):
 	def __cinit__(self,  Graph G, k=1, H=0):
 		self._G = G
 		self._this = new _GroupCloseness(G._this, k, H)
-
-	def __dealloc__(self):
-		del self._this
 
 	""" Returns group with highest closeness.
 	Returns
@@ -7547,10 +7511,6 @@ cdef class DynApproxBetweenness(Algorithm):
 		self._G = G
 		self._this = new _DynApproxBetweenness(G._this, epsilon, delta, storePredecessors, universalConstant)
 
-	# this is necessary so that the C++ object gets properly garbage collected
-	def __dealloc__(self):
-		del self._this
-
 	def update(self, ev):
 		""" Updates the betweenness centralities after the edge insertions.
 
@@ -7639,10 +7599,6 @@ cdef class DynBetweenness(Algorithm):
 	def __cinit__(self, Graph G):
 		self._G = G
 		self._this = new _DynBetweenness(G._this)
-
-	# this is necessary so that the C++ object gets properly garbage collected
-	def __dealloc__(self):
-		del self._this
 
 	def update(self, ev):
 		""" Updates the betweenness centralities after the edge insertions.
@@ -7813,9 +7769,6 @@ cdef class PermanenceCentrality(Algorithm):
 		self._this = new _PermanenceCentrality(G._this, P._this)
 		self._G = G
 		self._P = P
-
-	def __dealloc__(self):
-		del self._this
 
 	def getIntraClustering(self, node u):
 		return (<_PermanenceCentrality*>(self._this)).getIntraClustering(u)
@@ -8631,11 +8584,6 @@ cdef class KatzIndex(LinkPredictor):
 		else:
 			self._this = new _KatzIndex(G._this, maxPathLength, dampingValue)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns the similarity score for the given node-pair based on the Katz index specified during construction.
 
@@ -8675,11 +8623,6 @@ cdef class CommonNeighborsIndex(LinkPredictor):
 		else:
 			self._this = new _CommonNeighborsIndex(G._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns the number of common neighbors of the given nodes u and v.
 
@@ -8718,11 +8661,6 @@ cdef class PreferentialAttachmentIndex(LinkPredictor):
 			self._this = new _PreferentialAttachmentIndex()
 		else:
 			self._this = new _PreferentialAttachmentIndex(G._this)
-
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
 
 	def run(self, node u, node v):
 		""" Returns the product of the cardinalities of the neighborhoods regarding u and v.
@@ -8807,11 +8745,6 @@ cdef class JaccardIndex(LinkPredictor):
 		else:
 			self._this = new _JaccardIndex(G._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns the Jaccard index for the given node-pair (u, v).
 
@@ -8851,11 +8784,6 @@ cdef class AdamicAdarIndex(LinkPredictor):
 		else:
 			self._this = new _AdamicAdarIndex(G._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns the Adamic/Adar Index of the given node-pair (u, v).
 
@@ -8892,11 +8820,6 @@ cdef class UDegreeIndex(LinkPredictor):
 		else:
 			self._this = new _UDegreeIndex(G._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns the degree of the first node provided, namely u.
 
@@ -8932,11 +8855,6 @@ cdef class VDegreeIndex(LinkPredictor):
 			self._this = new _VDegreeIndex()
 		else:
 			self._this = new _VDegreeIndex(G._this)
-
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
 
 	def run(self, node u, node v):
 		""" Returns the degree of the second node provided, namely v.
@@ -8983,11 +8901,6 @@ cdef class AlgebraicDistanceIndex(LinkPredictor):
 			self._this = new _AlgebraicDistanceIndex(numberSystems, numberIterations, omega, norm)
 		else:
 			self._this = new _AlgebraicDistanceIndex(G._this, numberSystems, numberIterations, omega, norm)
-
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
 
 	def preprocess(self):
 		""" Executes necessary initializations.
@@ -9036,11 +8949,6 @@ cdef class NeighborhoodDistanceIndex(LinkPredictor):
 		else:
 			self._this = new _NeighborhoodDistanceIndex(G._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns the Neighborhood Distance index for the given node-pair (u, v).
 
@@ -9079,11 +8987,6 @@ cdef class TotalNeighborsIndex(LinkPredictor):
 			self._this = new _TotalNeighborsIndex()
 		else:
 			self._this = new _TotalNeighborsIndex(G._this)
-
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
 
 	def run(self, node u, node v):
 		""" Returns the number of total union-neighbors for the given node-pair (u, v).
@@ -9124,11 +9027,6 @@ cdef class NeighborsMeasureIndex(LinkPredictor):
 		else:
 			self._this = new _NeighborsMeasureIndex(G._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns the number of connections between neighbors of u and v.
 
@@ -9165,11 +9063,6 @@ cdef class SameCommunityIndex(LinkPredictor):
 		else:
 			self._this = new _SameCommunityIndex(G._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def run(self, node u, node v):
 		""" Returns 1 if the given nodes u and v are in the same community, 0 otherwise.
 
@@ -9205,11 +9098,6 @@ cdef class AdjustedRandIndex(LinkPredictor):
 			self._this = new _AdjustedRandIndex()
 		else:
 			self._this = new _AdjustedRandIndex(G._this)
-
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
 
 	def run(self, node u, node v):
 		""" Returns the Adjusted Rand Index of the given node-pair (u, v).
@@ -9249,11 +9137,6 @@ cdef class ResourceAllocationIndex(LinkPredictor):
 			self._this = new _ResourceAllocationIndex()
 		else:
 			self._this = new _ResourceAllocationIndex(G._this)
-
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
 
 	def run(self, node u, node v):
 		""" Returns the Resource Allocation Index of the given node-pair (u, v).
@@ -9425,11 +9308,6 @@ cdef class ROCMetric(EvaluationMetric):
 		else:
 			self._this = new _ROCMetric(testGraph._this)
 
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
-
 	def getCurve(self, vector[pair[pair[node, node], double]] predictions, count numThresholds = 1000):
 		""" Generate the points of the Receiver Operating Characteristic curve regarding the previously set predictions.
 
@@ -9471,11 +9349,6 @@ cdef class PrecisionRecallMetric(EvaluationMetric):
 			self._this = new _PrecisionRecallMetric()
 		else:
 			self._this = new _PrecisionRecallMetric(testGraph._this)
-
-	def __dealloc__(self):
-		if self._this is not NULL:
-			del self._this
-			self._this = NULL
 
 	def getCurve(self, vector[pair[pair[node, node], double]] predictions, count numThresholds = 1000):
 		""" Generates the points for the Precision-Recall curve with respect to the given predictions.
@@ -10659,9 +10532,6 @@ cdef class CommuteTimeDistance(Algorithm):
 		self._G = G
 		self._this = new _CommuteTimeDistance(G._this, tol)
 
-	def __dealloc__(self):
-		del self._this
-
 	def runApproximation(self):
 		""" Computes approximation of the ECTD. """
 		return (<_CommuteTimeDistance*>(self._this)).runApproximation()
@@ -10765,8 +10635,6 @@ cdef class SpanningEdgeCentrality(Algorithm):
 	def __cinit__(self,  Graph G, double tol = 0.1):
 		self._G = G
 		self._this = new _SpanningEdgeCentrality(G._this, tol)
-	def __dealloc__(self):
-		del self._this
 
 	def runApproximation(self):
 		""" Computes approximation of the Spanning Edge Centrality. This solves k linear systems, where k is log(n)/(tol^2). The empirical running time is O(km), where n is the number of nodes
@@ -11074,10 +10942,6 @@ cdef class GlobalCurveball(Algorithm):
 		else:
 			raise RuntimeError("Parameter G has to be a graph")
 
-	def __dealloc__(self):
-		del self._this
-		self._this = NULL
-
 	"""
 
 	Get randomized graph after invocation of run().
@@ -11201,10 +11065,6 @@ cdef class Curveball(Algorithm):
 			self._this = new _Curveball((<Graph>G)._this)
 		else:
 			raise RuntimeError("Parameter G has to be a graph")
-
-	def __dealloc__(self):
-		del self._this
-		self._this = NULL
 
 	def run(self, vector[pair[node, node]] trades):
 		with nogil:

--- a/networkit/cpp/randomization/CurveballImpl.cpp
+++ b/networkit/cpp/randomization/CurveballImpl.cpp
@@ -52,7 +52,7 @@ void CurveballAdjacencyList::initialize(const degree_vector& degrees,
     for (const count node_degree : degrees) {
         begins[node_id] = sum;
 
-        assert(node_degree > 0);
+        //assert(node_degree > 0);
 
         sum += node_degree;
         neighbours[sum] = LISTROW_END;

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,13 @@ ninja_available = False
 if sys.version_info.major < 3:
 	print("ERROR: NetworKit requires Python 3.")
 	sys.exit(1)
+
 if shutil.which("cmake") is None:
 	print("ERROR: NetworKit compilation requires cmake.")
 	sys.exit(1)
 
 ninja_available = shutil.which("ninja") is not None
-if not ninja_available or shutil.which("make") is None:
+if not (ninja_available or shutil.which("make")):
 	print("ERROR: NetworKit compilation requires Make or Ninja.")
 	sys.exit(1)
 try:

--- a/setup.py
+++ b/setup.py
@@ -95,12 +95,20 @@ if cmakeCompiler == "":
 ################################################
 
 def cythonizeFile(filepath):
+	cpp_file = filepath.replace("pyx","cpp")
+
 	cython_available = shutil.which("cython") is not None
-	if not cython_available and not os.path.isfile(filepath.replace("pyx","cpp")):
-		print("ERROR: Neither cython nor _NetworKit.cpp is provided. Build cancelled")
-		exit(1)
-	if not cython_available and os.path.isfile(filepath.replace("pyx","cpp")):
-		print("Cython not available, but _NetworKit.cpp provided. Continue build without cythonizing")
+	if not cython_available:
+		if not os.path.isfile(cpp_file):
+			print("ERROR: Neither cython nor _NetworKit.cpp is provided. Build cancelled", flush=True)
+			exit(1)
+
+		else:
+			print("Cython not available, but _NetworKit.cpp provided. Continue build without cythonizing", flush=True)
+
+	elif os.path.isfile(cpp_file) and os.path.getmtime(filepath) < os.path.getmtime(cpp_file):
+		print("Cython available; skip as _NetworKit.cpp was create after last modification of _NetworKit.pyx", flush=True)
+
 	else:
 		print("Cythonizing _NetworKit.pyx...", flush=True)
 		if not os.path.isfile(filepath):

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ parser.add_argument("-j", "--jobs", dest="jobs", help="specify number of jobs")
 (options,args) = parser.parse_known_args()
 if options.jobs is not None:
 	jobs = options.jobs
+if "NETWORKIT_PARALLEL_JOBS" in os.environ:
+    jobs = int(os.environ["NETWORKIT_PARALLEL_JOBS"])
 else:
 	import multiprocessing
 	jobs = multiprocessing.cpu_count()


### PR DESCRIPTION
This PR combines several improvements which I consider okay, since it's not targeting the Dev-branch yet.
- Rather than using OpenFlags as an parameter to `LINK_FLAGS` directly, this PR introduces the `NETWORKIT_LINK_FLAGS` proxy. This is partly to make MSVC porting easier, which treats the Flags subtle differently.
- Introduce `NETWORKIT_CXX_STANDARD` as parameter to make it possible to test NetworKit against higher standards during CI.
- `setup.py` now only invokes Cython if `_Networkit.cpp` is either missing or out-dated (its timestamp is older than `_Networkit.pyx`). This significantly speeds up recompilation.
- In monolithic builds define two tests with correctly set working path, to avoid the necessity of symlinks to the input/output directories in the build directory. Consequently, Travis hence does not call `networkit_tests` directly, but executes `ctest -V`.
- Travis now tests now also include a g++8 with CXX in {11,14,17} to spot future issues early on during CI
- Travis now also test the PIP installation. Here we have a slight issue since Travis worker expose 48 virtual cores, which causes OOM-issues during build. Unfortunatly passing `-j2` to setup.py requires `pip install --install-options="-j2"` which are also passed to all dependencies triggering fatal errors. This seems to be a known issues with PIP and I did not find a solution. For this reason, setup.py now also checks whether the environment variable `NETWORKIT_PARALLEL_JOBS` is set, and defaults the number of parallel jobs to it.

Remark: executing the unit tests in `networkit/tests/*` caues SegFaults; hence the failing Travis tests. I consider fixing this out-of-scope of this PR.