### PR TITLE
Fix Linux clang build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,18 +42,16 @@ matrix:
             - python3-pip
             - python3.4-venv
 
-    - env: CC=clang-3.7 CXX=clang++-3.7
+    - name: CC=clang-4 CXX=clang++-4
+      env: CC=/usr/local/opt/llvm@4/bin/clang
+      env: CXX=/usr/local/opt/llvm@4/bin/clang++
       os: osx
       sudo: false
       before_install:
         - brew update
-        - brew install llvm37
+        - brew install llvm@4
         - brew install libomp
         - brew upgrade python
-      install:
-        - export C_INCLUDE_PATH=$(llvm-config-3.7 --includedir)
-        - export CPLUS_INCLUDE_PATH=$(llvm-config-3.7 --includedir)
-        - export LIBRARY_PATH=$(llvm-config-3.7 --libdir)
 
     - env: CC=gcc-8 CXX=g++-8
       os: linux

--- a/networkit/cpp/community/CoverHubDominance.cpp
+++ b/networkit/cpp/community/CoverHubDominance.cpp
@@ -6,12 +6,13 @@
 #include "../auxiliary/SignalHandling.h"
 #include "../auxiliary/Parallel.h"
 #include <atomic>
+#include <memory>
 
 void NetworKit::CoverHubDominance::run() {
 	hasRun = false;
 	Aux::SignalHandler handler;
 
-	std::vector<std::atomic<count> > maxInternalDeg(C.upperBound());
+	std::unique_ptr<std::atomic<count>[]> maxInternalDeg(new std::atomic<count>[C.upperBound()]{});
 
 	handler.assureRunning();
 

--- a/networkit/cpp/community/PartitionHubDominance.cpp
+++ b/networkit/cpp/community/PartitionHubDominance.cpp
@@ -6,13 +6,14 @@
 #include "../auxiliary/SignalHandling.h"
 #include "../auxiliary/Parallel.h"
 #include <atomic>
+#include <memory>
 
 void NetworKit::PartitionHubDominance::run() {
 	hasRun = false;
 
 	Aux::SignalHandler handler;
 
-	std::vector<std::atomic<count> > maxInternalDeg(P.upperBound());
+	std::unique_ptr<std::atomic<count>[]> maxInternalDeg(new std::atomic<count>[P.upperBound()]{});
 	std::vector<count> clusterSizes(P.upperBound(), 0);
 
 	handler.assureRunning();

--- a/networkit/cpp/sparsification/LocalDegreeScore.cpp
+++ b/networkit/cpp/sparsification/LocalDegreeScore.cpp
@@ -7,6 +7,8 @@
 
 #include "LocalDegreeScore.h"
 #include "../auxiliary/Parallel.h"
+#include <atomic>
+#include <memory>
 
 namespace NetworKit {
 
@@ -32,7 +34,7 @@ void LocalDegreeScore::run() {
 		throw std::runtime_error("edges have not been indexed - call indexEdges first");
 	}
 
-	std::vector<std::atomic<double>> exponents (G.upperEdgeIdBound());
+	std::unique_ptr<std::atomic<double>[]> exponents(new std::atomic<double>[G.upperEdgeIdBound()]{});
 
 	G.balancedParallelForNodes([&](node i) {
 		count d = G.degree(i);

--- a/networkit/cpp/sparsification/LocalFilterScore.h
+++ b/networkit/cpp/sparsification/LocalFilterScore.h
@@ -10,6 +10,8 @@
 
 #include "../edgescores/EdgeScore.h"
 #include "../auxiliary/Parallel.h"
+#include <atomic>
+#include <memory>
 
 namespace NetworKit {
 
@@ -46,7 +48,7 @@ public:
 		* such that the edge is contained in the sparse graph.
 		*/
 
-		std::vector<std::atomic<double>> sparsificationExp(G.upperEdgeIdBound());
+		std::unique_ptr<std::atomic<double>[]> sparsificationExp(new std::atomic<double>[G.upperEdgeIdBound()]{});
 
 		G.balancedParallelForNodes([&](node i) {
 			count d = G.degree(i);

--- a/networkit/cpp/structures/Partition.cpp
+++ b/networkit/cpp/structures/Partition.cpp
@@ -9,6 +9,7 @@
 #include "../auxiliary/Parallel.h"
 #include <algorithm>
 #include <atomic>
+#include <memory>
 
 namespace NetworKit {
 
@@ -71,7 +72,7 @@ bool Partition::isOnePartition(Graph& G) { //FIXME what for is elements needed? 
 
 count Partition::numberOfSubsets() const {
 	auto n = upperBound();
-	std::vector<std::atomic<bool>> exists(n); // a boolean vector would not be thread-safe
+	std::unique_ptr<std::atomic<bool>[]> exists(new std::atomic<bool>[n]{}); // a boolean vector would not be thread-safe
 	this->parallelForEntries([&](index e, index s) {
 		if (s != none) {
 			exists[s] = true;

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,16 @@ import sys
 import shutil
 import os
 
-cmakeCompiler = "" #possibilty to specify a compiler
+cmakeCompiler = None
 buildDirectory = "build_python"
 ninja_available = False
 
 if sys.version_info.major < 3:
 	print("ERROR: NetworKit requires Python 3.")
 	sys.exit(1)
+
+if "NETWORKIT_OVERRIDE_CXX" in os.environ:
+	cmakeCompiler = os.environ["NETWORKIT_OVERRIDE_CXX"]
 
 if shutil.which("cmake") is None:
 	print("ERROR: NetworKit compilation requires cmake.")
@@ -39,7 +42,7 @@ parser.add_argument("-j", "--jobs", dest="jobs", help="specify number of jobs")
 if options.jobs is not None:
 	jobs = options.jobs
 if "NETWORKIT_PARALLEL_JOBS" in os.environ:
-    jobs = int(os.environ["NETWORKIT_PARALLEL_JOBS"])
+	jobs = int(os.environ["NETWORKIT_PARALLEL_JOBS"])
 else:
 	import multiprocessing
 	jobs = multiprocessing.cpu_count()
@@ -83,15 +86,15 @@ def determineCompiler(candidates, std, flags):
 			if subprocess.call(cmd,stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
 				os.remove("sample.cpp")
 				os.remove("test_build")
-				return compiler, std
+				return compiler
 		except:
 			pass
-	return "",""
+	return ""
 
 # only check for a compiler if none is specified
-if cmakeCompiler == "":
-	cmakeCompiler,_ = determineCompiler(candidates, "c++11", ["-fopenmp"])
-	if cmakeCompiler == "":
+if cmakeCompiler is None:
+	cmakeCompiler = determineCompiler(candidates, "c++11", ["-fopenmp"])
+	if cmakeCompiler is None:
 		print("ERROR: No suitable compiler found. Install any of these: ",candidates)
 		exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import sys
 import shutil
 import os


### PR DESCRIPTION
While the macOS clang build was broken because of LLVM bugs, the Linux clang build was broken because of NetworKit bugs. In particular, NetworKit relied on the undefined `std::vector<std::atomic<...>>` pattern. This PR fixes this issue.

Based on #203.