### PR TITLE
CMake environment - Documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,8 @@ script:
 
  - python3 -m venv pyenv && . pyenv/bin/activate
  - pip3 install --upgrade pip
- - NETWORKIT_PARALLEL_JOBS=2 pip3 install -e . 
+ - pip3 install cython # required because git does not contain _NetworKit
+ - NETWORKIT_PARALLEL_JOBS=2 pip3 install -e .
  - pip3 install ipython # required for tests
  - python3 -m unittest discover -v networkit/test/
 

--- a/version.py
+++ b/version.py
@@ -54,7 +54,6 @@ classifiers = [
 
 install_requires = [
 	'scipy',
-	'cython >= 0.21',
 	'matplotlib',
 	'pandas',
 	'numpy',


### PR DESCRIPTION
Despite the whole documentation needs a cleanup / rewrite at some point, this PR updates at least the  `README.md` in order to match the new build environment.

Documentation regarding the tests are intentionally left out because this should be documented in the `DevGuide.md`.

**NOTE** : This PR also removes cython from the install_requires field in `version.py`, because it is not required anymore if a `_NetworKit.cpp` is provided.