### PR TITLE
Race conditions in Aux::Random

### DIFF
--- a/networkit/cpp/auxiliary/Random.cpp
+++ b/networkit/cpp/auxiliary/Random.cpp
@@ -11,17 +11,6 @@
 
 #include "Random.h"
 
-// If GCC does not support thread local, we are sad and don't use it:
-#ifdef __GNUC__
-#	if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
-#		define AUX_THREAD_LOCAL thread_local
-#	else
-#		define AUX_THREAD_LOCAL
-#	endif
-#else // we don't know our plattform, so don't support it:
-#	define AUX_THREAD_LOCAL 
-#endif
-
 namespace Aux {
 namespace Random {
 
@@ -40,7 +29,7 @@ void setSeed(uint64_t seed, bool useThreadId) {
 
 uint64_t getSeed() {
 	if (!staticSeed) {
-		AUX_THREAD_LOCAL static std::random_device urng{};
+		thread_local static std::random_device urng{};
 		std::uniform_int_distribution<uint64_t> dist{};
 		return dist(urng);
 	} else if (seedUseThredId) {
@@ -50,10 +39,9 @@ uint64_t getSeed() {
 	}
 }
 
-
 std::mt19937_64& getURNG() {
-	AUX_THREAD_LOCAL static std::mt19937_64 generator{getSeed()};
-	AUX_THREAD_LOCAL static uint64_t localSeedGeneration = std::numeric_limits<uint64_t>::max();
+	thread_local static std::mt19937_64 generator{getSeed()};
+	thread_local static uint64_t localSeedGeneration = std::numeric_limits<uint64_t>::max();
 	if (staticSeed && localSeedGeneration != globalSeedGeneration) {
 		generator.seed(getSeed());
 		localSeedGeneration = globalSeedGeneration;
@@ -62,7 +50,7 @@ std::mt19937_64& getURNG() {
 }
 
 uint64_t integer() {
-	AUX_THREAD_LOCAL static std::uniform_int_distribution<uint64_t> dist{};
+	thread_local static std::uniform_int_distribution<uint64_t> dist{};
 	return dist(getURNG());
 }
 uint64_t integer(uint64_t upperBound) {
@@ -75,7 +63,7 @@ uint64_t integer(uint64_t lowerBound, uint64_t upperBound) {
 }
 
 double real() {
-	AUX_THREAD_LOCAL static std::uniform_real_distribution<double> dist{};
+	thread_local static std::uniform_real_distribution<double> dist{};
 	return dist(getURNG());
 }
 double real(double upperBound) {
@@ -88,7 +76,7 @@ double real(double lowerBound, double upperBound) {
 }
 
 double probability() {
-	AUX_THREAD_LOCAL static std::uniform_real_distribution<double> dist{0.0, std::nexttoward(1.0, 2.0)};
+	thread_local static std::uniform_real_distribution<double> dist{0.0, std::nexttoward(1.0, 2.0)};
 	return dist(getURNG());
 }
 

--- a/networkit/cpp/auxiliary/Random.h
+++ b/networkit/cpp/auxiliary/Random.h
@@ -46,6 +46,11 @@ std::mt19937_64& getURNG();
  * @returns an integer distributed uniformly in an inclusive range;
  * @param upperBound the upper bound, default = UNINT64_T_MAX
  * @param lowerBound the lower bound, default = 0
+ *
+ * @warning Compared to obtaining a reference to a generator using
+ * @ref getURNG() and then using a local std::uniform_int_distribution,
+ * this method incurs a slow-down of up to 30%. Consider avoiding it
+ * in hot sections.
  */
 uint64_t integer();
 uint64_t integer(uint64_t upperBound);
@@ -55,6 +60,11 @@ uint64_t integer(uint64_t lowerBound, uint64_t upperBound);
  * @returns a double distributed uniformly in a half-open range: [lowerBound, upperBound)
  * @param upperBound default = 1.0
  * @param lowerBound default = 0.0
+ *
+ * @warning Compared to obtaining a reference to a generator using
+ * @ref getURNG() and then using a local std::uniform_int_distribution,
+ * this method incurs a slow-down of up to 30%. Consider avoiding it
+ * in hot sections.
  */
 double real();
 double real(double upperBound);
@@ -63,6 +73,11 @@ double real(double lowerBound, double upperBound);
 /**
  * @returns a double distributed uniformly in the range [0, 1]
  * @note this differs from real() in returning a value in a closed instead of a half-open range.
+ *
+ * @warning Compared to obtaining a reference to a generator using
+ * @ref getURNG() and then using a local std::uniform_int_distribution,
+ * this method incurs a slow-down of up to 30%. Consider avoiding it
+ * in hot sections.
  */
 double probability();
 

--- a/networkit/cpp/auxiliary/Random.h
+++ b/networkit/cpp/auxiliary/Random.h
@@ -20,7 +20,7 @@ namespace Aux {
 /**
  * Provides several functions for random-numbers.
  *
- * All functions are guaranteed to be thread-safe if and only if at least GCC 4.8 is used
+ * All functions are guaranteed to be thread-safe.
  */
 namespace Random {
 
@@ -37,7 +37,7 @@ void setSeed(uint64_t seed, bool useThreadId);
 uint64_t getSeed();
 
 /**
- * @returns a reference to a seeded URNG that is thread_local iff GCC 4.8 or later is used.
+ * @returns a reference to a seeded URNG that is thread_local.
  */
 std::mt19937_64& getURNG();
 

--- a/networkit/cpp/auxiliary/Random.h
+++ b/networkit/cpp/auxiliary/Random.h
@@ -1,12 +1,12 @@
-#ifndef RANDOM_H_
-#define RANDOM_H_
-
 /*
  * Random.h
  *
  *  Created on: 02.01.2014
  *      Author: FJW
  */
+
+#ifndef RANDOM_H_
+#define RANDOM_H_
 
 #include <cassert>
 #include <cstddef>
@@ -71,14 +71,6 @@ double probability();
  * access a random element of a container.
  */
 std::size_t index(std::size_t max);
-
-/**
- * @returns an integer distributed binomially
- * @param n 	number of trials
- * @param p 	success probability
- */
-//uint64_t binomial(double n, double p);
-
 
 /**
  * @returns a uniform random choice from an indexable container of elements.

--- a/networkit/cpp/auxiliary/test/AuxRandomBenchmark.cpp
+++ b/networkit/cpp/auxiliary/test/AuxRandomBenchmark.cpp
@@ -22,6 +22,22 @@ static double measure(F f, const size_t iterations = 50000000) {
 	return (1.0e6 * ms / iterations);
 }
 
+template<typename F>
+static double measureParallel(F f) {
+	// TODO: replace with google benchmark infrastructure
+	std::atomic<uint64_t> atime{0}; // this is a very dirty hack, but atomic float-points are not fully support by standard
+	std::atomic<int> num_threads;
+
+	#pragma omp parallel
+	{
+		const double local_time = f();
+		num_threads.store(omp_get_num_threads());
+		atime.fetch_add(static_cast<uint64_t>(1e6 * local_time), std::memory_order_relaxed);
+	}
+
+	return 1e-6 * atime / num_threads;
+}
+
 TEST_F(AuxRandomBenchmark, benchmarkInteger) {
 	uint64_t tmp = 0;
 	auto atime = measure([&] {
@@ -46,41 +62,32 @@ TEST_F(AuxRandomBenchmark, benchmarkLocalDistrInteger) {
 }
 
 TEST_F(AuxRandomBenchmark, benchmarkIntegerParallel) {
-	double atime{0};
-
-	#pragma omp parallel
-	{
+	auto atime = measureParallel([] {
 		uint64_t tmp = 0;
 		auto local_time = measure([&] {
 			tmp += Aux::Random::integer();
-		}) / omp_get_num_threads();
+		});
 		volatile auto dummy = tmp;
 
-		#pragma omp atomic
-		atime += local_time;
-	}
+		return local_time;
+	});
 
 	std::cout << "Average time of operation: " << atime << "ns\n";
 }
 
 TEST_F(AuxRandomBenchmark, benchmarkLocalDistrIntegerParallel) {
-	double atime{0};
-
-	#pragma omp parallel
-	{
-		uint64_t tmp = 0;
+	auto atime = measureParallel([] {
 		auto &prng = Aux::Random::getURNG();
 		std::uniform_int_distribution<uint64_t> distr;
 
+		uint64_t tmp = 0;
 		auto local_time = measure([&] {
 			tmp += distr(prng);
-		}) / omp_get_num_threads();
-
+		});
 		volatile auto dummy = tmp;
 
-		#pragma omp atomic
-		atime += local_time;
-	}
+		return local_time;
+	});
 
 	std::cout << "Average time of operation: " << atime << "ns\n";
 }
@@ -110,41 +117,32 @@ TEST_F(AuxRandomBenchmark, benchmarkLocalDistrProb) {
 }
 
 TEST_F(AuxRandomBenchmark, benchmarkProbParallel) {
-	double atime{0};
-
-	#pragma omp parallel
-	{
+	auto atime = measureParallel([] {
 		double tmp = 0.0;
-		auto local_time = measure([&] {
+		auto local_time =  measure([&] {
 			tmp += Aux::Random::probability();
-		}) / omp_get_num_threads();
+		});
 		volatile auto dummy = tmp;
 
-		#pragma omp atomic
-		atime += local_time;
-	}
+		return local_time;
+	});
 
 	std::cout << "Average time of operation: " << atime << "ns\n";
 }
 
 TEST_F(AuxRandomBenchmark, benchmarkLocalDistrProbParallel) {
-	double atime{0};
-
-	#pragma omp parallel
-	{
-		double tmp = 0.0;
+	auto atime = measureParallel([] {
 		auto &prng = Aux::Random::getURNG();
 		std::uniform_real_distribution<double> distr{0.0, 1.0};
 
+		double tmp = 0.0;
 		auto local_time = measure([&] {
 			tmp += distr(prng);
-		}) / omp_get_num_threads();
-
+		});
 		volatile auto dummy = tmp;
 
-		#pragma omp atomic
-		atime += local_time;
-	}
+		return local_time;
+	});
 
 	std::cout << "Average time of operation: " << atime << "ns\n";
 }

--- a/networkit/cpp/auxiliary/test/AuxRandomBenchmark.cpp
+++ b/networkit/cpp/auxiliary/test/AuxRandomBenchmark.cpp
@@ -1,0 +1,152 @@
+#include "AuxRandomBenchmark.h"
+
+#include "../Random.h"
+#include "../Timer.h"
+
+#include <atomic>
+#include <random>
+#include "omp.h"
+
+namespace NetworKit {
+template<typename F>
+static double measure(F f, const size_t iterations = 50000000) {
+	Aux::Timer timer;
+	timer.start();
+
+	for (size_t i = 0; i < iterations; i++) {
+		f();
+	}
+
+	timer.stop();
+	const auto ms = timer.elapsedMilliseconds();
+	return (1.0e6 * ms / iterations);
+}
+
+TEST_F(AuxRandomBenchmark, benchmarkInteger) {
+	uint64_t tmp = 0;
+	auto atime = measure([&] {
+		tmp += Aux::Random::integer();
+	});
+	volatile auto dummy = tmp;
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+TEST_F(AuxRandomBenchmark, benchmarkLocalDistrInteger) {
+	uint64_t tmp = 0;
+
+	auto &prng = Aux::Random::getURNG();
+	std::uniform_int_distribution<uint64_t> distr;
+
+	auto atime = measure([&] {
+		tmp += distr(prng);
+	});
+
+	volatile auto dummy = tmp;
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+TEST_F(AuxRandomBenchmark, benchmarkIntegerParallel) {
+	double atime{0};
+
+	#pragma omp parallel
+	{
+		uint64_t tmp = 0;
+		auto local_time = measure([&] {
+			tmp += Aux::Random::integer();
+		}) / omp_get_num_threads();
+		volatile auto dummy = tmp;
+
+		#pragma omp atomic
+		atime += local_time;
+	}
+
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+TEST_F(AuxRandomBenchmark, benchmarkLocalDistrIntegerParallel) {
+	double atime{0};
+
+	#pragma omp parallel
+	{
+		uint64_t tmp = 0;
+		auto &prng = Aux::Random::getURNG();
+		std::uniform_int_distribution<uint64_t> distr;
+
+		auto local_time = measure([&] {
+			tmp += distr(prng);
+		}) / omp_get_num_threads();
+
+		volatile auto dummy = tmp;
+
+		#pragma omp atomic
+		atime += local_time;
+	}
+
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+
+TEST_F(AuxRandomBenchmark, benchmarkProb) {
+	double tmp = 0.0;
+	auto atime = measure([&] {
+		tmp += Aux::Random::probability();
+	});
+	volatile auto dummy = tmp;
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+TEST_F(AuxRandomBenchmark, benchmarkLocalDistrProb) {
+	double tmp = 0.0;
+
+	auto &prng = Aux::Random::getURNG();
+	std::uniform_real_distribution<double> distr{0.0, 1.0};
+
+	auto atime = measure([&] {
+		tmp += distr(prng);
+	});
+
+	volatile auto dummy = tmp;
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+TEST_F(AuxRandomBenchmark, benchmarkProbParallel) {
+	double atime{0};
+
+	#pragma omp parallel
+	{
+		double tmp = 0.0;
+		auto local_time = measure([&] {
+			tmp += Aux::Random::probability();
+		}) / omp_get_num_threads();
+		volatile auto dummy = tmp;
+
+		#pragma omp atomic
+		atime += local_time;
+	}
+
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+TEST_F(AuxRandomBenchmark, benchmarkLocalDistrProbParallel) {
+	double atime{0};
+
+	#pragma omp parallel
+	{
+		double tmp = 0.0;
+		auto &prng = Aux::Random::getURNG();
+		std::uniform_real_distribution<double> distr{0.0, 1.0};
+
+		auto local_time = measure([&] {
+			tmp += distr(prng);
+		}) / omp_get_num_threads();
+
+		volatile auto dummy = tmp;
+
+		#pragma omp atomic
+		atime += local_time;
+	}
+
+	std::cout << "Average time of operation: " << atime << "ns\n";
+}
+
+} // ! namespace NetworKit

--- a/networkit/cpp/auxiliary/test/AuxRandomBenchmark.h
+++ b/networkit/cpp/auxiliary/test/AuxRandomBenchmark.h
@@ -1,0 +1,17 @@
+/*
+ * AuxRandomBenchmark.h
+ *
+ *  Created on: 09.08.2018
+ *      Author: Manuel Penschuck <networkit@manuel.jetzt>
+ */
+
+#ifndef AUXRANDOMBENCHMARK_H_
+#define AUXRANDOMBENCHMARK_H_
+
+#include <gtest/gtest.h>
+
+class AuxRandomBenchmark: public testing::Test {
+
+};
+
+#endif /* AUXRANDOMBENCHMARK_H_ */

--- a/networkit/cpp/auxiliary/test/CMakeLists.txt
+++ b/networkit/cpp/auxiliary/test/CMakeLists.txt
@@ -1,2 +1,4 @@
 networkit_add_test(auxiliary AuxGTest)
 
+networkit_add_benchmark(auxiliary AuxRandomBenchmark)
+


### PR DESCRIPTION
Aux::Random offers `thread_local` references to random number generators and distributions. If the code does not recognize that the compiler supports the `thread_local` keyword, it silently uses non-`thread_local` instances. The test however only checked for GCC>4.8, Clang never used thread_local!

If a user assumes (for good reason) that its references are thread-local and the detection fails, we get race-conditions and false-sharing, i.e. slow code broken code. I did not check which algorithms are affected, but my new code certainly was.

IMHO we should expect `thread_local` from a compiler nowadays. If its not supported we should be very verbose about it, and have a compile-time error.

Another issue in Aux::Random was the treatment of seed-values, which involved inter-thread communication between via non-atomic global variables. I removed one unnecessary variable and made the remaining once atomic.

The PR also includes a small benchmark to quantify the overhead cause when using convenient functions such as `Aux::Random::probability()`. They all involve static variable, extra instructions are issued by the compiler to check proper initialization. Also, if LTO is not used, additional calls are required. All together, using something like the following is roughly 30% faster than repeated calls to `Aux::Random::*`:
```cpp
auto& gen = getURNG();
std::uniform_read_distribution distr {...};
for (.... large number ....) {
   auto prob = distr(gen);
}
```

I hence add a warning in the documentation.
