### PR TITLE
Fix virtual warnings

### DIFF
--- a/networkit/cpp/randomization/Curveball.h
+++ b/networkit/cpp/randomization/Curveball.h
@@ -36,7 +36,7 @@ public:
 
 	virtual std::string toString() const override final;
 
-	virtual bool isParallel() const {
+	virtual bool isParallel() const override final {
 		return false;
 	}
 

--- a/networkit/cpp/randomization/GlobalCurveball.h
+++ b/networkit/cpp/randomization/GlobalCurveball.h
@@ -48,7 +48,7 @@ public:
 
     virtual std::string toString() const override final;
 
-    virtual bool isParallel() const {
+    virtual bool isParallel() const override final {
         return false;
     }
 

--- a/networkit/cpp/scd/PageRankNibble.h
+++ b/networkit/cpp/scd/PageRankNibble.h
@@ -40,6 +40,8 @@ public:
 	 */
 	PageRankNibble(const Graph& g, double alpha, double epsilon);
 
+	virtual ~PageRankNibble() = default;
+
 	virtual std::map<node, std::set<node> >  run(const std::set<node>& seeds) override;
 
 	/**

--- a/networkit/cpp/scd/SelectiveCommunityDetector.h
+++ b/networkit/cpp/scd/SelectiveCommunityDetector.h
@@ -20,6 +20,7 @@ class SelectiveCommunityDetector {
 public:
 
 	SelectiveCommunityDetector(const Graph& G);
+	virtual ~SelectiveCommunityDetector() = default;
 
     /**
      * Detect communities for given seed nodes.


### PR DESCRIPTION
Clang rightfully complains, that the virtual abstract class `SelectiveCommunityDetector` inherited by `PageRankNibble` does not contain a virtual destructor despite it's required in the Unit Test. This PR adds it.

Also, Clang thinks `Curveball::isParallel` should be annotated with `override`. So why not ;)