### PR TITLE
Break Travis tests into individual configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,30 @@ matrix:
         - brew install libomp
         - brew upgrade cmake # cmake on osx images (xode9.4) is on 3.11.4 - 3.12+ required 
 
+    # Test more exotic builds only on Linux.
+    - name: "Linux, modern GCC: Core build, debugging"
+      env: CC=gcc-8 CXX=g++-8
+      os: linux
+      addons: *gcc8
+      script:
+        - $CXX --version
+        - mkdir debug_test && cd "$_"
+        - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ..
+        - make -j2
+        - ctest -V
 
+    - name: "Linux, modern GCC: Core build, non-monolithic"
+      env: CC=gcc-8 CXX=g++-8
+      os: linux
+      addons: *gcc8
+      script:
+        - $CXX --version
+        - mkdir build_non_monolith && cd "$_"
+        - cmake -DNETWORKIT_MONOLITH=OFF -DCMAKE_BUILD_TYPE=Debug ..
+        - make -j2
+        - ctest -V
+
+    # Finally, test conformance to newer versions of the C++ standard.
     - name: C++14 conformance
       env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=14
       os: linux
@@ -125,23 +148,11 @@ script:
  - NETWORKIT_PARALLEL_JOBS=2 travis_wait pip3 install -e .
  - python3 -m unittest discover -v networkit/test/
 
- - mkdir debug_test && cd "$_"
- - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
- - make -j2
- - ctest -V
- - cd .. && rm -rf debug_test
-
  - mkdir release_test && cd "$_"
  - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
  - make -j2
  - ctest -V
  - cd .. && rm -rf release_test
-
- - mkdir build_non_monolith && cd "$_"
- - cmake -DNETWORKIT_MONOLITH=OFF -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
- - make -j2
- - ctest -V
- - cd .. && rm -rf build_non_monolith
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,11 +94,18 @@ matrix:
       env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=14
       os: linux
       addons: *gcc8
+      script: &script_cpp_only
+        - $CXX --version
+        - mkdir debug_test && cd "$_"
+        - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
+        - make -j2
+        - ctest -V
 
     - name: C++17 conformance
       env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=17
       os: linux
       addons: *gcc8
+      script: *script_cpp_only
 
   allow_failures:
     - name: macOS, modern Clang


### PR DESCRIPTION
As discussed in #236, currently Travis builds take way too long. This PR aims to reduce the latency of the CI pipeline by breaking the Travis script into multiple smaller configurations.

As a result, the total build time decreases from [5 h 13 min](https://travis-ci.org/kit-parco/networkit/builds/435527511) to [3h 18 min](https://travis-ci.org/kit-parco/networkit/builds/435585051). The maximal time for a single configuration decreases from 47 min to 32 min.