### PR TITLE
Support Python build with external NetworKit core library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,14 +145,20 @@ script:
  # cython is required because git does not contain _NetworKit.
  # ipython is required for tests.
  - pip3 install cython ipython
- - NETWORKIT_PARALLEL_JOBS=2 travis_wait pip3 install -e .
- - python3 -m unittest discover -v networkit/test/
 
- - mkdir release_test && cd "$_"
+ # First, build the C++ core library and run C++ tests.
+ - mkdir core_build && cd "$_"
  - cmake -DNETWORKIT_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DNETWORKIT_CXX_STANDARD=$CXX_STANDARD ..
  - make -j2
  - ctest -V
- - cd .. && rm -rf release_test
+ - cd ..
+
+ # Finally, build the Python extension and run Python tests.
+ - export CMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH:+$CMAKE_LIBRARY_PATH:}$(pwd)/core_build
+ - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$(pwd)/core_build
+ - NETWORKIT_PARALLEL_JOBS=2 python3 ./setup.py build_ext --inplace --networkit-external-core
+ - NETWORKIT_PARALLEL_JOBS=2 pip3 install -e .
+ - python3 -m unittest discover -v networkit/test/
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
 endif("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
 
 # BUILD OPTIONS
-option(NETWORKIT_BUILD_TESTS "Build with tests" OFF)
+option(NETWORKIT_BUILD_CORE "Build NetworKit core library" ON)
+option(NETWORKIT_BUILD_TESTS "Build NetworKit C++ tests" OFF)
 option(NETWORKIT_LOGGING "Build with logging support" ON)
 option(NETWORKIT_STATIC "Build static libraries" OFF)
 option(NETWORKIT_MONOLITH "Build single library (and tests is requested; required for shared lib)" ON)
@@ -128,7 +129,7 @@ if(NETWORKIT_INCLUDESYMLINK)
 endif()
 
 # NETWORKIT MODULES
-if (NETWORKIT_MONOLITH)
+if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 	if(NETWORKIT_STATIC)
 		add_library(networkit networkit/cpp/networkit.cpp)
 	else()
@@ -176,6 +177,10 @@ endif()
 # Register a new NetworKit module named ${modname}
 # Files additionally passed are interpreted as PUBLIC source files to this module
 function(networkit_add_module modname)
+	if(NOT NETWORKIT_BUILD_CORE)
+		return()
+	endif()
+
 	if(NETWORKIT_MONOLITH)
 		# in case we are building a monolith, no submodule are registered
 		# and we simple add the source file to the networkkit target
@@ -222,7 +227,11 @@ function(networkit_module_link_libraries modname)
 	cmake_parse_arguments(NMLL
 		"${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-	if (NOT NETWORKIT_MONOLITH)
+	if(NOT NETWORKIT_BUILD_CORE)
+		return()
+	endif()
+
+	if(NOT NETWORKIT_MONOLITH)
 		target_link_libraries(networkit_${modname}
 			PRIVATE ${NMLL_PRIVATE}
 			PUBLIC ${NMLL_PUBLIC})
@@ -234,7 +243,11 @@ endfunction()
 # ones as dependencies. In case of monolith build, the function does nothing.
 # Example: networkit_module_link_modules(io graph) # io depends on graph
 function(networkit_module_link_modules modname)
-	if (NOT NETWORKIT_MONOLITH)
+	if(NOT NETWORKIT_BUILD_CORE)
+		return()
+	endif()
+
+	if(NOT NETWORKIT_MONOLITH)
 		foreach(dep IN LISTS ARGN)
 			target_link_libraries(networkit_${modname} PUBLIC networkit_${dep})
 		endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
 # BUILD OPTIONS
 option(NETWORKIT_BUILD_TESTS "Build with tests" OFF)
 option(NETWORKIT_LOGGING "Build with logging support" ON)
+option(NETWORKIT_STATIC "Build static libraries" OFF)
 option(NETWORKIT_MONOLITH "Build single library (and tests is requested; required for shared lib)" ON)
 option(NETWORKIT_NATIVE "Optimize for native architecture (often better performance)" OFF)
 option(NETWORKIT_WARNINGS "Issue more warnings" OFF)
@@ -128,10 +129,10 @@ endif()
 
 # NETWORKIT MODULES
 if (NETWORKIT_MONOLITH)
-	if (NETWORKIT_PYTHON)
-		add_library(networkit SHARED networkit/cpp/networkit.cpp)
-	else()
+	if(NETWORKIT_STATIC)
 		add_library(networkit networkit/cpp/networkit.cpp)
+	else()
+		add_library(networkit SHARED networkit/cpp/networkit.cpp)
 	endif()
 
 	set_target_properties(networkit PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,32 +146,32 @@ if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 			ARCHIVE DESTINATION .)
 
 	target_link_libraries(networkit PRIVATE tlx)
+endif()
 
-	if (NETWORKIT_PYTHON)
-		if(EXISTS "${PROJECT_SOURCE_DIR}/networkit/_NetworKit.cpp")
-			add_library(_NetworKit MODULE networkit/_NetworKit.cpp)
-			target_link_libraries(_NetworKit PRIVATE networkit)
-			target_include_directories(_NetworKit PRIVATE "${NETWORKIT_PYTHON}")
-			set_target_properties(_NetworKit PROPERTIES
-						CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
-						COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
-						LINK_FLAGS "${NETWORKIT_LINK_FLAGS}"
-						PREFIX ""
-						OUTPUT_NAME "_NetworKit.${NETWORKIT_PYTHON_SOABI}")
-			# DSOs on Apple OSes use different conventions for RPATH.
-			if(APPLE)
-				set_target_properties(_NetworKit PROPERTIES
-						INSTALL_RPATH "@loader_path")
-			else()
-				set_target_properties(_NetworKit PROPERTIES
-						INSTALL_RPATH "$ORIGIN")
-			endif()
-			install(TARGETS _NetworKit
-					LIBRARY DESTINATION .)
-		else()
-			message(FATAL_ERROR "networkit/_NetworKit.cpp is missing. Invoke Cython manually.")
-		endif()
+if (NETWORKIT_PYTHON)
+	if(NOT EXISTS "${PROJECT_SOURCE_DIR}/networkit/_NetworKit.cpp")
+		message(FATAL_ERROR "networkit/_NetworKit.cpp is missing. Invoke Cython manually.")
 	endif()
+
+	add_library(_NetworKit MODULE networkit/_NetworKit.cpp)
+	target_link_libraries(_NetworKit PRIVATE networkit)
+	target_include_directories(_NetworKit PRIVATE "${NETWORKIT_PYTHON}")
+	set_target_properties(_NetworKit PROPERTIES
+				CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
+				COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
+				LINK_FLAGS "${NETWORKIT_LINK_FLAGS}"
+				PREFIX ""
+				OUTPUT_NAME "_NetworKit.${NETWORKIT_PYTHON_SOABI}")
+	# DSOs on Apple OSes use different conventions for RPATH.
+	if(APPLE)
+		set_target_properties(_NetworKit PROPERTIES
+				INSTALL_RPATH "@loader_path")
+	else()
+		set_target_properties(_NetworKit PROPERTIES
+				INSTALL_RPATH "$ORIGIN")
+	endif()
+	install(TARGETS _NetworKit
+			LIBRARY DESTINATION .)
 endif()
 
 # Register a new NetworKit module named ${modname}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ if (APPLE)
 	set(NETWORKIT_LINK_FLAGS "-undefined dynamic_lookup ${NETWORKIT_LINK_FLAGS}")
 endif()
 
+if(NOT NETWORKIT_BUILD_CORE)
+	find_library(EXTERNAL_NETWORKIT_CORE NAMES networkit DOC "External NetworKit core library")
+endif()
+
 ################################################################################
 # Use TLX as a CMake submodule
 if(EXISTS "${PROJECT_SOURCE_DIR}/extlibs/tlx/CMakeLists.txt")
@@ -148,14 +152,23 @@ if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 	target_link_libraries(networkit PRIVATE tlx)
 endif()
 
-if (NETWORKIT_PYTHON)
+if(NETWORKIT_PYTHON)
 	if(NOT EXISTS "${PROJECT_SOURCE_DIR}/networkit/_NetworKit.cpp")
 		message(FATAL_ERROR "networkit/_NetworKit.cpp is missing. Invoke Cython manually.")
 	endif()
 
 	add_library(_NetworKit MODULE networkit/_NetworKit.cpp)
-	target_link_libraries(_NetworKit PRIVATE networkit)
 	target_include_directories(_NetworKit PRIVATE "${NETWORKIT_PYTHON}")
+
+	if(NOT NETWORKIT_BUILD_CORE)
+		if(NOT EXTERNAL_NETWORKIT_CORE)
+			message(FATAL_ERROR "Core build is disabled but no external core library was found.")
+		endif()
+		target_link_libraries(_NetworKit PRIVATE ${EXTERNAL_NETWORKIT_CORE})
+	else()
+		target_link_libraries(_NetworKit PRIVATE networkit)
+	endif()
+
 	set_target_properties(_NetworKit PROPERTIES
 				CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
 				COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ before_build:
 
     cd build
 
-    cmake -G "Visual Studio 15 Win64" -DNETWORKIT_BUILD_TESTS=ON ..
+    cmake -G "Visual Studio 15 Win64" -DNETWORKIT_STATIC=ON -DNETWORKIT_BUILD_TESTS=ON ..
 build:
   project: c:\dev\networkit\build\networkit.sln
   parallel: true

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ def cythonizeFile(filepath):
 			exit(1)
 		print("_NetworKit.pyx cythonized", flush=True)
 
-def buildNetworKit(install_prefix, withTests = False):
+def buildNetworKit(install_prefix, externalCore=False, withTests=False):
 	# Cythonize file
 	cythonizeFile("networkit/_NetworKit.pyx")
 	try:
@@ -155,6 +155,8 @@ def buildNetworKit(install_prefix, withTests = False):
 	from sysconfig import get_paths, get_config_var
 	comp_cmd.append("-DNETWORKIT_PYTHON="+get_paths()['include']) #provide python.h files
 	comp_cmd.append("-DNETWORKIT_PYTHON_SOABI="+get_config_var('SOABI')) #provide lib env specification
+	if externalCore:
+		comp_cmd.append("-DNETWORKIT_BUILD_CORE=OFF")
 	if ninja_available:
 		comp_cmd.append("-GNinja")
 	comp_cmd.append(os.getcwd()) #call CMakeLists.txt from networkit root
@@ -200,6 +202,8 @@ class build_ext(Command):
 			"list of directories to search for header files" + sep_by),
 		('library-dirs=', 'L',
 			"directories to search for external C libraries" + sep_by),
+		('networkit-external-core', None,
+			"use external NetworKit core library")
 	]
 
 	def initialize_options(self):
@@ -209,6 +213,7 @@ class build_ext(Command):
 		self.inplace = False
 		self.include_dirs = None
 		self.library_dirs = None
+		self.networkit_external_core = False
 
 		self.extensions = None
 		self.package = None
@@ -247,7 +252,7 @@ class build_ext(Command):
 			# The --inplace implementation is less sophisticated than in distutils,
 			# but it should be sufficient for NetworKit.
 			prefix = self.distribution.src_root or os.getcwd()
-		buildNetworKit(prefix)
+		buildNetworKit(prefix, externalCore=self.networkit_external_core)
 
 ################################################
 # initialize python setup


### PR DESCRIPTION
This is another PR to reduce Travis' build times (see #236); however, the functionality implemented in this PR might also be interesting on its own:

We extend the build system to allow building the Python extention without building the NetworKit core (i.e. C++) library. This is done by passing -DNETWORKIT_BUILD_CORE=OFF to cmake and requires an external prebuilt copy of the core library. Our Travis script is modified to take advantage of this feature.

I should remark that after this PR, NetworKit is built as a shared library by default. This can be deactivated using -DNETWORKIT_STATIC but is no longer coupled to -DNETWORKIT_PYTHON.

This PR reduces Travis build times from [3 h 50 min](https://travis-ci.org/kit-parco/networkit/builds/436732224) to [3 h 5 min](https://travis-ci.org/kit-parco/networkit/builds/436805470); it also decreases latency and the maximal time for a single build considerably.

Pinging @manpen as he gave some comments in #236.