### PR TITLE
Kadabra: skip useless shortest-path computations

### DIFF
--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -343,7 +343,7 @@ void KadabraBetweenness::run() {
 
 #pragma omp parallel
 	{
-		SpSampler sampler(G, cc);
+		SpSampler sampler(G, *cc);
 		while (nPairs <= tau) {
 			oneRound(sampler);
 			++nPairs;
@@ -367,7 +367,7 @@ void KadabraBetweenness::run() {
 
 #pragma omp parallel
 	{
-		SpSampler sampler(G, cc);
+		SpSampler sampler(G, *cc);
 		Status status(unionSample);
 		status.nPairs = 0;
 
@@ -406,12 +406,9 @@ void KadabraBetweenness::run() {
 	if (!absolute) {
 		delete (top);
 	}
-	if (!G.isDirected()) {
-		delete (cc);
-	}
 }
 
-SpSampler::SpSampler(const Graph &G, ConnectedComponents *cc)
+SpSampler::SpSampler(const Graph &G, const ConnectedComponents &cc)
     : G(G), n(G.upperNodeIdBound()), pred(n, false, true), cc(cc) {
 	q.resize(n);
 	ballInd.assign(n, 0);
@@ -426,7 +423,7 @@ std::vector<node> SpSampler::randomPath() {
 		v = G.randomNode();
 	}
 
-	if (!G.isDirected() && cc->componentOfNode(u) != cc->componentOfNode(v)) {
+	if (!G.isDirected() && cc.componentOfNode(u) != cc.componentOfNode(v)) {
 		return std::vector<node>();
 	}
 

--- a/networkit/cpp/centrality/KadabraBetweenness.h
+++ b/networkit/cpp/centrality/KadabraBetweenness.h
@@ -12,6 +12,7 @@
 
 #include "../auxiliary/SortedList.h"
 #include "../base/Algorithm.h"
+#include "../components/ConnectedComponents.h"
 #include "../graph/Graph.h"
 
 namespace NetworKit {
@@ -31,7 +32,7 @@ public:
 
 class SpSampler {
 public:
-	SpSampler(const Graph &G);
+	SpSampler(const Graph &G, ConnectedComponents *cc);
 	std::vector<node> randomPath();
 
 private:
@@ -42,6 +43,7 @@ private:
 	std::vector<count> dist;
 	std::vector<count> nPaths;
 	std::vector<node> q;
+	ConnectedComponents *cc;
 
 	inline node randomNode() const;
 	void backtrackPath(const node u, const node v, const node start,
@@ -154,6 +156,7 @@ protected:
 	std::vector<double> topkScores;
 	std::vector<std::pair<node, double>> rankingVector;
 	Aux::SortedList *top;
+	ConnectedComponents *cc;
 
 	std::vector<std::vector<double>> approx;
 	std::vector<double> approxSum;

--- a/networkit/cpp/centrality/KadabraBetweenness.h
+++ b/networkit/cpp/centrality/KadabraBetweenness.h
@@ -32,7 +32,7 @@ public:
 
 class SpSampler {
 public:
-	SpSampler(const Graph &G, ConnectedComponents *cc);
+	SpSampler(const Graph &G, const ConnectedComponents &cc);
 	std::vector<node> randomPath();
 
 private:
@@ -43,7 +43,7 @@ private:
 	std::vector<count> dist;
 	std::vector<count> nPaths;
 	std::vector<node> q;
-	ConnectedComponents *cc;
+	const ConnectedComponents &cc;
 
 	inline node randomNode() const;
 	void backtrackPath(const node u, const node v, const node start,

--- a/networkit/cpp/components/ConnectedComponents.h
+++ b/networkit/cpp/components/ConnectedComponents.h
@@ -45,7 +45,7 @@ public:
 	 *
 	 * @param[in]	u	The node whose component is asked for.
 	 */
-	count componentOfNode(node u);
+	count componentOfNode(node u) const;
 
 
 	/**
@@ -73,7 +73,7 @@ private:
 	bool hasRun;
 };
 
-inline count ConnectedComponents::componentOfNode(node u) {
+inline count ConnectedComponents::componentOfNode(node u) const {
 	assert (component[u] != none);
 	if (!hasRun) throw std::runtime_error("run method has not been called");
 	return component[u];


### PR DESCRIPTION
In undirected graphs Kadabra looks if a sampled pair is within the same CC. If not, it skips the computation of the shortest path because it would lead to an empty path anyway.
This does not affect the distribution of the sampled pairs.