### PR TITLE
Removed allowed failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,11 +130,6 @@ matrix:
       addons: *gcc8
       script: *script_cpp_only
 
-  allow_failures:
-    - name: macOS, modern Clang
-    - name: macOS, legacy Clang 4
-    - name: macOS, AppleClang
-
 script:
  - $CXX --version
  - python3 --version


### PR DESCRIPTION
Travis macos image seems to have been fixed so we shall not allow those builds to fail anymore.