### PR TITLE
Removed unnecessary NetworKit namespace usages

### DIFF
--- a/networkit/cpp/centrality/ApproxBetweenness.h
+++ b/networkit/cpp/centrality/ApproxBetweenness.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  * Approximation of betweenness centrality according to algorithm described in
  * Matteo Riondato and Evgenios M. Kornaropoulos: Fast Approximation of Betweenness Centrality through Sampling
  */
-class ApproxBetweenness: public NetworKit::Centrality {
+class ApproxBetweenness: public Centrality {
 
 public:
 

--- a/networkit/cpp/centrality/ApproxCloseness.h
+++ b/networkit/cpp/centrality/ApproxCloseness.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  * Approximation of closeness centrality according to algorithm described in
  * Cohen et al., Computing Classic Closeness Centrality, at Scale
  */
-class ApproxCloseness: public NetworKit::Centrality {
+class ApproxCloseness: public Centrality {
 
 public:
 	enum CLOSENESS_TYPE {INBOUND, OUTBOUND, SUM};

--- a/networkit/cpp/centrality/Betweenness.h
+++ b/networkit/cpp/centrality/Betweenness.h
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class Betweenness: public NetworKit::Centrality {
+class Betweenness: public Centrality {
 public:
 	/**
 	 * Constructs the Betweenness class for the given Graph @a G. If the betweenness scores should be normalized,

--- a/networkit/cpp/centrality/Closeness.h
+++ b/networkit/cpp/centrality/Closeness.h
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class Closeness: public NetworKit::Centrality {
+class Closeness: public Centrality {
 public:
 	/**
 	 * Constructs the Closeness class for the given Graph @a G. If the closeness scores should be normalized,

--- a/networkit/cpp/centrality/CoreDecomposition.h
+++ b/networkit/cpp/centrality/CoreDecomposition.h
@@ -23,7 +23,7 @@ namespace NetworKit {
  * @ingroup centrality
  * Computes k-core decomposition of a graph.
  */
-class CoreDecomposition : public NetworKit::Centrality  {
+class CoreDecomposition : public Centrality  {
 
 public:
 

--- a/networkit/cpp/centrality/DegreeCentrality.h
+++ b/networkit/cpp/centrality/DegreeCentrality.h
@@ -17,7 +17,7 @@ namespace NetworKit {
  * Node centrality index which ranks nodes by their degree.
  * Optional normalization by maximum degree.
  */
-class DegreeCentrality: public NetworKit::Centrality {
+class DegreeCentrality: public Centrality {
 public:
 	/**
 	 * Constructs the DegreeCentrality class for the given Graph @a G. If the centrality scores should be normalized,

--- a/networkit/cpp/centrality/EstimateBetweenness.h
+++ b/networkit/cpp/centrality/EstimateBetweenness.h
@@ -20,7 +20,7 @@ namespace NetworKit {
  * There is no proven theoretical guarantee on the quality of the approximation. However, the algorithm was shown to perform well in practice.
  * If a guarantee is required, use ApproxBetweenness.
  */
-class EstimateBetweenness: public NetworKit::Centrality {
+class EstimateBetweenness: public Centrality {
 
 public:
 

--- a/networkit/cpp/centrality/HarmonicCloseness.h
+++ b/networkit/cpp/centrality/HarmonicCloseness.h
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class HarmonicCloseness : public NetworKit::Centrality {
+class HarmonicCloseness : public Centrality {
 public:
   /**
    * Constructs the HarmonicCloseness class for the given Graph @a G. If

--- a/networkit/cpp/centrality/KPathCentrality.h
+++ b/networkit/cpp/centrality/KPathCentrality.h
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class KPathCentrality: public NetworKit::Centrality {
+class KPathCentrality: public Centrality {
 public:
 
 	/*

--- a/networkit/cpp/centrality/LocalClusteringCoefficient.h
+++ b/networkit/cpp/centrality/LocalClusteringCoefficient.h
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup centrality
  */
-class LocalClusteringCoefficient: public NetworKit::Centrality {
+class LocalClusteringCoefficient: public Centrality {
 public:
 	/**
 	 * Constructs the LocalClusteringCoefficient class for the given Graph @a G. If the local clustering coefficient scores should be normalized,

--- a/networkit/cpp/centrality/PageRank.h
+++ b/networkit/cpp/centrality/PageRank.h
@@ -19,7 +19,7 @@ namespace NetworKit {
  * directed graphs; we follow the verbal description, which requires to sum over the incoming
  * edges (as opposed to outgoing ones).
  */
-class PageRank: public NetworKit::Centrality {
+class PageRank: public Centrality {
 protected:
 	double damp;
 	double tol;

--- a/networkit/cpp/centrality/Sfigality.h
+++ b/networkit/cpp/centrality/Sfigality.h
@@ -16,7 +16,7 @@ namespace NetworKit {
  * @ingroup centrality
  * A
  */
-class Sfigality: public NetworKit::Centrality {
+class Sfigality: public Centrality {
 public:
 	/**
 	 * Constructs the Sfigality class for the given Graph @a G. Sfigality is a new type of

--- a/networkit/cpp/centrality/SpanningEdgeCentrality.h
+++ b/networkit/cpp/centrality/SpanningEdgeCentrality.h
@@ -21,7 +21,7 @@ namespace NetworKit {
  * SpanningEdgeCentrality edge centrality.
  *
  */
-class SpanningEdgeCentrality: public NetworKit::Centrality {
+class SpanningEdgeCentrality: public Centrality {
 protected:
 	double tol;
 	Lamg<CSRMatrix> lamg;

--- a/networkit/cpp/coarsening/ParallelPartitionCoarsening.h
+++ b/networkit/cpp/coarsening/ParallelPartitionCoarsening.h
@@ -17,7 +17,7 @@ namespace NetworKit {
 /**
  * @ingroup coarsening
  */
-class ParallelPartitionCoarsening: public NetworKit::GraphCoarsening {
+class ParallelPartitionCoarsening: public GraphCoarsening {
 public:
 	ParallelPartitionCoarsening(const Graph& G, const Partition& zeta, bool useGraphBuilder = true);
 

--- a/networkit/cpp/community/Conductance.h
+++ b/networkit/cpp/community/Conductance.h
@@ -19,7 +19,7 @@ namespace NetworKit {
  * Compute conductance of a 2-partition, i.e. cut size over volume of smaller set (smaller in
  * terms of volume).
  */
-class Conductance: public NetworKit::QualityMeasure {
+class Conductance: public QualityMeasure {
 public:
 	/**
 	 * @return Conductance of 2-partition @a zeta in graph @a G.

--- a/networkit/cpp/community/Coverage.h
+++ b/networkit/cpp/community/Coverage.h
@@ -16,7 +16,7 @@ namespace NetworKit {
  * @ingroup community
  * Coverage is the fraction of intra-cluster edges.
  */
-class Coverage: public NetworKit::QualityMeasure {
+class Coverage: public QualityMeasure {
 public:
 
 	virtual double getQuality(const Partition& zeta, const Graph& G);

--- a/networkit/cpp/community/DynamicNMIDistance.h
+++ b/networkit/cpp/community/DynamicNMIDistance.h
@@ -18,7 +18,7 @@ typedef std::vector<std::vector<count> > Matrix;
 /**
  * @ingroup community
  */
-class DynamicNMIDistance: public NetworKit::DissimilarityMeasure {
+class DynamicNMIDistance: public DissimilarityMeasure {
 public:
 
 	/**

--- a/networkit/cpp/community/EdgeCut.h
+++ b/networkit/cpp/community/EdgeCut.h
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup community
  */
-class EdgeCut: public NetworKit::QualityMeasure {
+class EdgeCut: public QualityMeasure {
 public:
 	virtual double getQuality(const Partition& zeta, const Graph& G);
 };

--- a/networkit/cpp/community/GraphStructuralRandMeasure.h
+++ b/networkit/cpp/community/GraphStructuralRandMeasure.h
@@ -17,7 +17,7 @@ namespace NetworKit {
  * The graph-structural Rand measure assigns a similarity value in [0,1]
  * to two partitions of a graph, by considering connected pairs of nodes.
  */
-class GraphStructuralRandMeasure: public NetworKit::DissimilarityMeasure {
+class GraphStructuralRandMeasure: public DissimilarityMeasure {
 
 public:
 

--- a/networkit/cpp/community/JaccardMeasure.h
+++ b/networkit/cpp/community/JaccardMeasure.h
@@ -15,7 +15,7 @@ namespace NetworKit {
 /**
  * @ingroup community
  */
-class JaccardMeasure: public NetworKit::DissimilarityMeasure {
+class JaccardMeasure: public DissimilarityMeasure {
 
 public:
 

--- a/networkit/cpp/community/LPDegreeOrdered.h
+++ b/networkit/cpp/community/LPDegreeOrdered.h
@@ -19,7 +19,7 @@ typedef index label; // a label is the same as a cluster id
  * Label propagation-based community detection algorithm which
  * processes nodes in increasing order of node degree.
  */
-class LPDegreeOrdered: public NetworKit::CommunityDetectionAlgorithm {
+class LPDegreeOrdered: public CommunityDetectionAlgorithm {
 private:
 	count nIterations = 0;	//!< number of iterations in last run
 

--- a/networkit/cpp/community/Modularity.h
+++ b/networkit/cpp/community/Modularity.h
@@ -24,7 +24,7 @@ namespace NetworKit {
  * 	$$mod(\zeta) := \frac{\sum_{C \in \zeta} \sum_{ e \in E(C) } \omega(e)}{\sum_{e \in E} \omega(e)}
  * 	- \frac{ \sum_{C \in \zeta}( \sum_{v \in C} \omega(v) )^2 }{4( \sum_{e \in E} \omega(e) )^2 }$$
  */
-class Modularity: public NetworKit::QualityMeasure {
+class Modularity: public QualityMeasure {
 protected:
 	double gTotalEdgeWeight;
 

--- a/networkit/cpp/community/NMIDistance.h
+++ b/networkit/cpp/community/NMIDistance.h
@@ -19,7 +19,7 @@ namespace NetworKit {
  * Normalized Mutual Information.
  *
  */
-class NMIDistance: public NetworKit::DissimilarityMeasure {
+class NMIDistance: public DissimilarityMeasure {
 
 public:
 

--- a/networkit/cpp/community/NodeStructuralRandMeasure.h
+++ b/networkit/cpp/community/NodeStructuralRandMeasure.h
@@ -17,7 +17,7 @@ namespace NetworKit {
  * The node-structural Rand measure assigns a similarity value in [0,1]
  * to two partitions of a graph, by considering all pairs of nodes.
  */
-class NodeStructuralRandMeasure: public NetworKit::DissimilarityMeasure {
+class NodeStructuralRandMeasure: public DissimilarityMeasure {
 
 public:
 

--- a/networkit/cpp/community/PLM.h
+++ b/networkit/cpp/community/PLM.h
@@ -16,7 +16,7 @@ namespace NetworKit {
  * @ingroup community
  * Parallel Louvain Method - a multi-level modularity maximizer.
  */
-class PLM: public NetworKit::CommunityDetectionAlgorithm {
+class PLM: public CommunityDetectionAlgorithm {
 
 public:
 	/**

--- a/networkit/cpp/community/PLP.h
+++ b/networkit/cpp/community/PLP.h
@@ -23,7 +23,7 @@ namespace NetworKit {
  * has the label that at least half of its neighbors have.
  *
  */
-class PLP: public NetworKit::CommunityDetectionAlgorithm {
+class PLP: public CommunityDetectionAlgorithm {
 
 protected:
 

--- a/networkit/cpp/community/ParallelAgglomerativeClusterer.h
+++ b/networkit/cpp/community/ParallelAgglomerativeClusterer.h
@@ -16,7 +16,7 @@ namespace NetworKit {
  * @ingroup community
  * A parallel agglomerative community detection algorithm, maximizing modularity.
  */
-class ParallelAgglomerativeClusterer: public NetworKit::CommunityDetectionAlgorithm {
+class ParallelAgglomerativeClusterer: public CommunityDetectionAlgorithm {
 
 public:
 	/**

--- a/networkit/cpp/community/SampledGraphStructuralRandMeasure.h
+++ b/networkit/cpp/community/SampledGraphStructuralRandMeasure.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  * to two partitions of a graph, by considering connected pairs of nodes.
  * This implementation approximates the index by sampling.
  */
-class SampledGraphStructuralRandMeasure: public NetworKit::DissimilarityMeasure {
+class SampledGraphStructuralRandMeasure: public DissimilarityMeasure {
 
 public:
 

--- a/networkit/cpp/community/SampledNodeStructuralRandMeasure.h
+++ b/networkit/cpp/community/SampledNodeStructuralRandMeasure.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  * to two partitions of a graph, by considering pairs of nodes.
  * This implementation approximates the index by sampling.
  */
-class SampledNodeStructuralRandMeasure: public NetworKit::DissimilarityMeasure {
+class SampledNodeStructuralRandMeasure: public DissimilarityMeasure {
 
 public:
 

--- a/networkit/cpp/distance/AlgebraicDistance.h
+++ b/networkit/cpp/distance/AlgebraicDistance.h
@@ -20,7 +20,7 @@ namespace NetworKit {
  * Algebraic distances will become small within dense subgraphs.
  *
  */
-class AlgebraicDistance: public NetworKit::NodeDistance {
+class AlgebraicDistance: public NodeDistance {
 
 public:
 

--- a/networkit/cpp/distance/JaccardDistance.h
+++ b/networkit/cpp/distance/JaccardDistance.h
@@ -20,7 +20,7 @@ namespace NetworKit {
  * Jaccard distance assigns a distance value to pairs of nodes
  * according to the similarity of their neighborhoods. Note that we define the JaccardDistance as 1-JaccardSimilarity.
  */
-class JaccardDistance: public NetworKit::NodeDistance {
+class JaccardDistance: public NodeDistance {
 
 public:
 

--- a/networkit/cpp/generators/BarabasiAlbertGenerator.h
+++ b/networkit/cpp/generators/BarabasiAlbertGenerator.h
@@ -16,7 +16,7 @@ namespace NetworKit {
  * @ingroup generators
  * Generates a scale-free graph using the Barabasi-Albert preferential attachment model.
  */
-class BarabasiAlbertGenerator: public NetworKit::StaticGraphGenerator {
+class BarabasiAlbertGenerator: public StaticGraphGenerator {
 private:
 	Graph initGraph;
 	count k; //!< Attachments made per node

--- a/networkit/cpp/generators/ClusteredRandomGraphGenerator.h
+++ b/networkit/cpp/generators/ClusteredRandomGraphGenerator.h
@@ -19,7 +19,7 @@ namespace NetworKit {
  * The number of nodes and the number of edges are adjustable as well as the probabilities
  * for intra-cluster and inter-cluster edges.
  */
-class ClusteredRandomGraphGenerator: public NetworKit::StaticGraphGenerator {
+class ClusteredRandomGraphGenerator: public StaticGraphGenerator {
 public:
 	/**
 	 * Creates a clustered random graph:

--- a/networkit/cpp/generators/DynamicBarabasiAlbertGenerator.h
+++ b/networkit/cpp/generators/DynamicBarabasiAlbertGenerator.h
@@ -19,7 +19,7 @@ namespace NetworKit {
 /**
  * @ingroup generators
  */
-class DynamicBarabasiAlbertGenerator: public NetworKit::DynamicGraphSource {
+class DynamicBarabasiAlbertGenerator: public DynamicGraphSource {
 
 protected:
 

--- a/networkit/cpp/generators/DynamicDGSParser.h
+++ b/networkit/cpp/generators/DynamicDGSParser.h
@@ -24,7 +24,7 @@ namespace NetworKit {
 /**
  * @ingroup generators
  */
-class DynamicDGSParser: public NetworKit::DynamicGraphSource {
+class DynamicDGSParser: public DynamicGraphSource {
 public:
 	DynamicDGSParser(std::string path);
 

--- a/networkit/cpp/generators/DynamicDorogovtsevMendesGenerator.h
+++ b/networkit/cpp/generators/DynamicDorogovtsevMendesGenerator.h
@@ -16,7 +16,7 @@ namespace NetworKit {
 /**
  * @ingroup generators
  */
-class DynamicDorogovtsevMendesGenerator: public NetworKit::DynamicGraphGenerator {
+class DynamicDorogovtsevMendesGenerator: public DynamicGraphGenerator {
 
 public:
 

--- a/networkit/cpp/generators/DynamicForestFireGenerator.h
+++ b/networkit/cpp/generators/DynamicForestFireGenerator.h
@@ -23,7 +23,7 @@ namespace NetworKit {
  * see Leskovec, Kleinberg, Faloutsos: Graphs over Tim: Densification Laws,
  * 	Shringking Diameters and Possible Explanations
  */
-class DynamicForestFireGenerator: public NetworKit::DynamicGraphGenerator {
+class DynamicForestFireGenerator: public DynamicGraphGenerator {
 
 public:
 

--- a/networkit/cpp/generators/DynamicHyperbolicGenerator.h
+++ b/networkit/cpp/generators/DynamicHyperbolicGenerator.h
@@ -16,7 +16,7 @@
 
 namespace NetworKit {
 
-class DynamicHyperbolicGenerator: public NetworKit::DynamicGraphGenerator  {
+class DynamicHyperbolicGenerator: public DynamicGraphGenerator  {
 	friend class GeneratorsGTest;
 public:
 	/**

--- a/networkit/cpp/generators/DynamicPathGenerator.h
+++ b/networkit/cpp/generators/DynamicPathGenerator.h
@@ -17,7 +17,7 @@ namespace NetworKit {
  * @ingroup generators
  * Example dynamic graph generator: Generates a dynamically growing path.
  */
-class DynamicPathGenerator: public NetworKit::DynamicGraphGenerator {
+class DynamicPathGenerator: public DynamicGraphGenerator {
 public:
 
 	std::vector<GraphEvent> generate(count nSteps) override;

--- a/networkit/cpp/generators/DynamicPubWebGenerator.h
+++ b/networkit/cpp/generators/DynamicPubWebGenerator.h
@@ -22,7 +22,7 @@ namespace NetworKit {
 /**
  * @ingroup generators
  */
-class DynamicPubWebGenerator: public NetworKit::DynamicGraphGenerator {
+class DynamicPubWebGenerator: public DynamicGraphGenerator {
 
 protected:
 	PubWebGenerator initGen; // multiple inheritance did not work with different generate functions

--- a/networkit/cpp/generators/HavelHakimiGenerator.h
+++ b/networkit/cpp/generators/HavelHakimiGenerator.h
@@ -23,7 +23,7 @@ namespace NetworKit {
  * Construction runs in linear time O(m). However, the test if a sequence is realizable
  * is quadratic in the sequence length.
  */
-class HavelHakimiGenerator: public NetworKit::StaticDegreeSequenceGenerator  {
+class HavelHakimiGenerator: public StaticDegreeSequenceGenerator  {
 protected:
 
 public:

--- a/networkit/cpp/generators/HyperbolicGenerator.h
+++ b/networkit/cpp/generators/HyperbolicGenerator.h
@@ -18,7 +18,7 @@
 
 namespace NetworKit {
 
-class HyperbolicGenerator: public NetworKit::StaticGraphGenerator {
+class HyperbolicGenerator: public StaticGraphGenerator {
 	friend class DynamicHyperbolicGenerator;
 public:
 

--- a/networkit/cpp/generators/PubWebGenerator.h
+++ b/networkit/cpp/generators/PubWebGenerator.h
@@ -54,7 +54,7 @@ struct circle {
  * - neighborhoodRadius: the higher, the better the connectivity [0.1, 0.35]
  * - maxNumberOfNeighbors: maximum degree, a higher value corresponds to better connectivity [4, 40]
  */
-class PubWebGenerator: public NetworKit::StaticGraphGenerator {
+class PubWebGenerator: public StaticGraphGenerator {
 
 	friend class DynamicPubWebGenerator;
 

--- a/networkit/cpp/generators/RmatGenerator.h
+++ b/networkit/cpp/generators/RmatGenerator.h
@@ -21,7 +21,7 @@ namespace NetworKit {
  * Deepayan Chakrabarti, Yiping Zhan, Christos Faloutsos:
  * R-MAT: A Recursive Model for Graph Mining. SDM 2004: 442-446.
  */
-class RmatGenerator: public NetworKit::StaticGraphGenerator {
+class RmatGenerator: public StaticGraphGenerator {
 protected:
 	count scale; ///< n = 2^scale
 	count edgeFactor;

--- a/networkit/cpp/generators/StaticDegreeSequenceGenerator.h
+++ b/networkit/cpp/generators/StaticDegreeSequenceGenerator.h
@@ -19,7 +19,7 @@ const short UNKNOWN = 2;
 /**
  * @ingroup generators
  */
-class StaticDegreeSequenceGenerator: public NetworKit::StaticGraphGenerator {
+class StaticDegreeSequenceGenerator: public StaticGraphGenerator {
 protected:
 	std::vector<count> seq;
 	short realizable;

--- a/networkit/cpp/independentset/Luby.h
+++ b/networkit/cpp/independentset/Luby.h
@@ -19,7 +19,7 @@ namespace NetworKit {
  * Luby's parallel independent set algorithm.
  */
 class [[deprecated]]
-Luby: public NetworKit::IndependentSetFinder {
+Luby: public IndependentSetFinder {
 
 public:
 

--- a/networkit/cpp/io/DGSReader.h
+++ b/networkit/cpp/io/DGSReader.h
@@ -30,7 +30,7 @@ namespace NetworKit {
  * Format documentation: http://graphstream-project.org/doc/Advanced-Concepts/The-DGS-File-Format/
  *
  */
-class DGSReader: public NetworKit::DynamicGraphReader {
+class DGSReader: public DynamicGraphReader {
 
 public:
 	

--- a/networkit/cpp/io/DibapGraphReader.h
+++ b/networkit/cpp/io/DibapGraphReader.h
@@ -35,7 +35,7 @@ namespace NetworKit {
  * @ingroup io
  * TODO: class documentation
  */
-class DibapGraphReader: public NetworKit::GraphReader {
+class DibapGraphReader: public GraphReader {
 public:
 	DibapGraphReader() = default;
 

--- a/networkit/cpp/io/EdgeListReader.h
+++ b/networkit/cpp/io/EdgeListReader.h
@@ -24,7 +24,7 @@ namespace NetworKit {
  * two node ids.
  *
  */
-class EdgeListReader: public NetworKit::GraphReader {
+class EdgeListReader: public GraphReader {
 
 public:
 

--- a/networkit/cpp/io/GMLGraphReader.h
+++ b/networkit/cpp/io/GMLGraphReader.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  *
  * [1] http://www.fim.uni-passau.de/fileadmin/files/lehrstuhl/brandenburg/projekte/gml/gml-technical-report.pdf
  */
-class GMLGraphReader: public NetworKit::GraphReader {
+class GMLGraphReader: public GraphReader {
 public:
 
 	GMLGraphReader() = default;

--- a/networkit/cpp/io/GMLGraphWriter.h
+++ b/networkit/cpp/io/GMLGraphWriter.h
@@ -20,7 +20,7 @@ namespace NetworKit {
  *
  * [1] http://svn.bigcat.unimaas.nl/pvplugins/GML/trunk/docs/gml-technical-report.pdf
  */
-class GMLGraphWriter: public NetworKit::GraphWriter {
+class GMLGraphWriter: public GraphWriter {
 public:
 	/** Default constructor */
 	GMLGraphWriter() = default;

--- a/networkit/cpp/io/GraphToolBinaryReader.h
+++ b/networkit/cpp/io/GraphToolBinaryReader.h
@@ -22,7 +22,7 @@ namespace NetworKit {
  * Reads graphs from files in the binary format defined by graph-tool[1].
  * [1]: http://graph-tool.skewed.de/static/doc/gt_format.html
  */
-class GraphToolBinaryReader: public NetworKit::GraphReader {
+class GraphToolBinaryReader: public GraphReader {
 
 public:
 

--- a/networkit/cpp/io/GraphToolBinaryWriter.h
+++ b/networkit/cpp/io/GraphToolBinaryWriter.h
@@ -22,7 +22,7 @@ namespace NetworKit {
  * Writes graphs to files in the binary format defined by graph-tool[1].
  * [1]: http://graph-tool.skewed.de/static/doc/gt_format.html
  */
-class GraphToolBinaryWriter: public NetworKit::GraphWriter {
+class GraphToolBinaryWriter: public GraphWriter {
 
 public:
 

--- a/networkit/cpp/io/KONECTGraphReader.h
+++ b/networkit/cpp/io/KONECTGraphReader.h
@@ -14,7 +14,7 @@
 #include "GraphReader.h"
 
 namespace NetworKit {
-  class KONECTGraphReader : public NetworKit::GraphReader{
+  class KONECTGraphReader : public GraphReader{
 
 	public:
 		[[deprecated("New Constructor - Use standardized seperator and Graph.removeSelfLoops instead")]]

--- a/networkit/cpp/io/METISGraphReader.h
+++ b/networkit/cpp/io/METISGraphReader.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  *
  * [1] http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/manual.pdf
  */
-class METISGraphReader: public NetworKit::GraphReader {
+class METISGraphReader: public GraphReader {
 public:
 
 	METISGraphReader() = default;

--- a/networkit/cpp/io/METISGraphWriter.h
+++ b/networkit/cpp/io/METISGraphWriter.h
@@ -17,7 +17,7 @@ namespace NetworKit {
 /**
  * @ingroup io
  */
-class METISGraphWriter: public NetworKit::GraphWriter {
+class METISGraphWriter: public GraphWriter {
 
 public:
 

--- a/networkit/cpp/io/MatrixMarketReader.h
+++ b/networkit/cpp/io/MatrixMarketReader.h
@@ -19,7 +19,7 @@ namespace NetworKit {
  *
  * Only allows real, symmetric matrices.
  */
-class MatrixMarketReader: public NetworKit::MatrixReader {
+class MatrixMarketReader: public MatrixReader {
 public:
 
   MatrixMarketReader() = default;

--- a/networkit/cpp/io/SNAPGraphReader.h
+++ b/networkit/cpp/io/SNAPGraphReader.h
@@ -17,7 +17,7 @@ namespace NetworKit {
 /**
  * @ingroup io
  */
-class SNAPGraphReader : public NetworKit::GraphReader {
+class SNAPGraphReader : public GraphReader {
 private:
 	std::unordered_map<node, node> nodeIdMap;
 	bool directed;

--- a/networkit/cpp/io/SNAPGraphWriter.h
+++ b/networkit/cpp/io/SNAPGraphWriter.h
@@ -44,7 +44,7 @@ namespace NetworKit {
  *
  * Good job
  */
-class SNAPGraphWriter: public NetworKit::GraphWriter {
+class SNAPGraphWriter: public GraphWriter {
 public:
 	SNAPGraphWriter() = default;
 	virtual void write(const Graph& G, const std::string& path) override;

--- a/networkit/cpp/io/ThrillGraphBinaryReader.h
+++ b/networkit/cpp/io/ThrillGraphBinaryReader.h
@@ -21,7 +21,7 @@ namespace NetworKit {
 /**
  * Reads a graph format consisting of a serialized DIA of vector<uint32_t> from thrill.
  */
-class ThrillGraphBinaryReader: public NetworKit::GraphReader {
+class ThrillGraphBinaryReader: public GraphReader {
 
 public:
 

--- a/networkit/cpp/matching/LocalMaxMatcher.h
+++ b/networkit/cpp/matching/LocalMaxMatcher.h
@@ -21,7 +21,7 @@ namespace NetworKit {
  * LocalMax matching similar to the one described in the EuroPar13 paper
  * by the Sanders group (Birn, Osipov, Sanders, Schulz, Sitchinava)
  */
-class LocalMaxMatcher: public NetworKit::Matcher {
+class LocalMaxMatcher: public Matcher {
 public:
 
 	LocalMaxMatcher(const Graph& G);

--- a/networkit/cpp/matching/PathGrowingMatcher.h
+++ b/networkit/cpp/matching/PathGrowingMatcher.h
@@ -20,7 +20,7 @@ namespace NetworKit {
  * Computes an approximate maximum weight matching with guarantee 1/2.
  * (Note that better algorithms in terms of approximation quality exist.)
  */
-class PathGrowingMatcher: public NetworKit::Matcher {
+class PathGrowingMatcher: public Matcher {
 public:
 	/**
 	 * @param[in] G Graph for which matching is computed.

--- a/networkit/cpp/overlap/HashingOverlapper.h
+++ b/networkit/cpp/overlap/HashingOverlapper.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  * @ingroup overlap
  * Determines the overlap of multiple partitions by hashing partition identifiers.
  */
-class HashingOverlapper: public NetworKit::Overlapper {
+class HashingOverlapper: public Overlapper {
 
 public:
 

--- a/networkit/cpp/scd/GCE.h
+++ b/networkit/cpp/scd/GCE.h
@@ -22,7 +22,7 @@ namespace NetworKit {
  *
  * Greedily adds nodes from the shell to improve community quality.
  */
-class GCE: public NetworKit::SelectiveCommunityDetector {
+class GCE: public SelectiveCommunityDetector {
 
 public:
 

--- a/networkit/cpp/scoring/ModularityScoring.h
+++ b/networkit/cpp/scoring/ModularityScoring.h
@@ -21,7 +21,7 @@ namespace NetworKit {
  * @ingroup scoring
  */
 template<typename T>
-class ModularityScoring: public NetworKit::EdgeScoring<T> {
+class ModularityScoring: public EdgeScoring<T> {
 
 protected:
 

--- a/networkit/cpp/simulation/EpidemicSimulationSEIR.h
+++ b/networkit/cpp/simulation/EpidemicSimulationSEIR.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  * Node centrality index which ranks nodes by their degree.
  * Optional normalization by maximum degree.
  */
-class EpidemicSimulationSEIR: public NetworKit::Algorithm {
+class EpidemicSimulationSEIR: public Algorithm {
 public:
 	/**
 	 *

--- a/networkit/cpp/viz/FruchtermanReingold.h
+++ b/networkit/cpp/viz/FruchtermanReingold.h
@@ -32,7 +32,7 @@ const double EPS = 0.1;
 
 
 class [[deprecated]]
-FruchtermanReingold: public NetworKit::Layouter {
+FruchtermanReingold: public Layouter {
 private:
 	static const float INITIAL_STEP_LENGTH;
 	static const float OPT_PAIR_SQR_DIST_SCALE;

--- a/networkit/cpp/viz/MultilevelLayouter.h
+++ b/networkit/cpp/viz/MultilevelLayouter.h
@@ -18,7 +18,7 @@ namespace NetworKit {
  */
 // TODO: refactor to inherit from LayoutAlgorithm base class
 class [[deprecated]]
-MultilevelLayouter: public NetworKit::Layouter {
+MultilevelLayouter: public Layouter {
 protected:
 	static const count N_THRSH;
 


### PR DESCRIPTION
Several classes use the NetworKit namespace when already inside the NetworKit namespace.

