### PR TITLE
Seaborn and sklearn are now optional requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+seaborn
+sklearn

--- a/version.py
+++ b/version.py
@@ -59,6 +59,5 @@ install_requires = [
 	'numpy',
 	'networkx',
 	'tabulate',
-	'seaborn',
-	'sklearn'
+	'ipython'
 ]


### PR DESCRIPTION
Seaborn and sklearn are not strictly required so we should move them to the `requirements.txt` file. Also, `ipython` seems to be necessary so we should include it in the `version.py` file.