### PR TITLE
NetworKit shallow clone on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: generic
 
+git:
+  depth: 1
+
 env:
   global:
     - export OMP_NUM_THREADS=2


### PR DESCRIPTION
By default travis clones the repository with a depth of 50 commits. Builds may be a bit faster if it does a shallow clone.