### PR TITLE
Add community.CoverF1Similarity

### DIFF
--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -5314,6 +5314,45 @@ cdef class StablePartitionNodes(LocalPartitionEvaluation):
 			raise RuntimeError("Error, object not properly initialized")
 		return (<_StablePartitionNodes*>(self._this)).isStable(u)
 
+
+cdef extern from "cpp/community/CoverF1Similarity.h":
+	cdef cppclass _CoverF1Similarity "NetworKit::CoverF1Similarity"(_LocalCoverEvaluation):
+		_CoverF1Similarity(_Graph G, _Cover C, _Cover reference) except +
+
+cdef class CoverF1Similarity(LocalCoverEvaluation):
+	"""
+	Compare a given cover to a reference cover using the F1 measure.
+	This is a typical similarity measure used to compare the found
+	overlapping community structure to a ground truth community
+	structure. Each cluster is compared to the best-matching reference
+	cluster (in terms of highest F1 score). A value of 1 indicates
+	perfect agreement while a while of 0 indicates complete
+	disagreement. An example where this measure is used is the
+	following paper:
+
+	Alessandro Epasto, Silvio Lattanzi, and Renato Paes
+	Leme. 2017. Ego-Splitting Framework: from Non-Overlapping to
+	Overlapping Clusters. In Proceedings of the 23rd ACM SIGKDD
+	International Conference on Knowledge Discovery and Data Mining
+	(KDD '17). ACM, New York, NY, USA, 145-154. DOI:
+	https://doi.org/10.1145/3097983.3098054
+
+	Parameters
+	----------
+	G : Graph
+		The graph on which the evaluation is performed.
+	C : Cover
+		The cover that shall be evaluated
+        reference : Cover
+		The cover to which the similarity shall be computed
+	"""
+	cdef Cover _reference
+	def __cinit__(self, Graph G not None, Cover C not None, Cover reference not None):
+		self._this = new _CoverF1Similarity(G._this, C._this, reference._this)
+		self._reference = reference
+		assert(self._G == G)
+		assert(self._C == C)
+
 # Module: flows
 
 cdef extern from "cpp/flow/EdmondsKarp.h":

--- a/networkit/community.py
+++ b/networkit/community.py
@@ -7,7 +7,8 @@ from _NetworKit import Partition, Coverage, Modularity, CommunityDetector, PLP, 
 	NodeStructuralRandMeasure, GraphStructuralRandMeasure, JaccardMeasure, NMIDistance, AdjustedRandMeasure,\
 	StablePartitionNodes, IntrapartitionDensity, PartitionHubDominance, CoverHubDominance, PartitionFragmentation, IsolatedInterpartitionExpansion, IsolatedInterpartitionConductance,\
 	EdgeListPartitionReader, GraphClusteringTools, ClusteringGenerator, PartitionIntersection, HubDominance, CoreDecomposition, CutClustering, ParallelPartitionCoarsening, \
-	BinaryPartitionReader, BinaryPartitionWriter, BinaryEdgeListPartitionReader, BinaryEdgeListPartitionWriter
+	BinaryPartitionReader, BinaryPartitionWriter, BinaryEdgeListPartitionReader, BinaryEdgeListPartitionWriter, \
+	CoverF1Similarity
 
 # R.I.P.: The CNM (Clauset, Newman, Moore) community detection algorithm - it was always a bit slow, but it broke down in the end. Resurrect it from history (<= 3.4.1) if needed for experimental purposes.
 

--- a/networkit/cpp/community/CMakeLists.txt
+++ b/networkit/cpp/community/CMakeLists.txt
@@ -4,6 +4,7 @@ networkit_add_module(community
     CommunityDetectionAlgorithm.cpp
     Conductance.cpp
     CoverHubDominance.cpp
+    CoverF1Similarity.cpp
     Coverage.cpp
     CutClustering.cpp
     DissimilarityMeasure.cpp

--- a/networkit/cpp/community/CoverF1Similarity.cpp
+++ b/networkit/cpp/community/CoverF1Similarity.cpp
@@ -1,0 +1,99 @@
+#include "CoverF1Similarity.h"
+
+#include "../auxiliary/SignalHandling.h"
+
+namespace NetworKit {
+
+CoverF1Similarity::CoverF1Similarity(const Graph &G, const Cover &C, const Cover &reference) : LocalCoverEvaluation(G, C), reference(reference) {}
+
+void CoverF1Similarity::run() {
+	hasRun = false;
+	Aux::SignalHandler handler;
+
+	std::vector<std::vector<node>> Csets(C.upperBound());
+	std::vector<count> referenceSizes(reference.upperBound(), 0);
+	count numMemberships = 0;
+
+	handler.assureRunning();
+
+	// Calculate cluster sizes and explicitly store all clusters of C
+	G.forNodes([&](node u) {
+		for (index c : C[u]) {
+			Csets[c].push_back(u);
+		}
+
+		for (index c : reference[u]) {
+			++referenceSizes[c];
+		}
+
+		numMemberships += C[u].size();
+	});
+
+	handler.assureRunning();
+
+	// Initialize result values
+	unweightedAverage = 0;
+	weightedAverage = 0;
+	minimumValue = std::numeric_limits<double>::max();
+	maximumValue = std::numeric_limits<double>::lowest();
+	values.clear();
+	values.resize(C.upperBound(), 0);
+
+	count numClusters = 0;
+
+	// The overlap of the currently considered cluster in C with each reference cluster
+	std::vector<count> overlap(reference.upperBound(), 0);
+	// The clusters of the reference that have a positive overlap
+	std::vector<index> overlappingReference;
+
+	for (index i = 0; i < C.upperBound(); ++i) {
+		if (Csets[i].size() > 0) {
+			++numClusters;
+
+			for (node u : Csets[i]) {
+				for (index s : reference[u]) {
+					if (overlap[s] == 0) {
+						overlappingReference.push_back(s);
+					}
+
+					++overlap[s];
+				}
+			}
+
+			double bestF1 = 0;
+
+			for (index s : overlappingReference) {
+				count ol = overlap[s];
+				assert(ol > 0);
+
+				// Reset values
+				overlap[s] = 0;
+
+				double precision = ol * 1.0 / referenceSizes[s];
+				double recall = ol * 1.0 / Csets[i].size();
+
+				double f1 = 2 * (precision * recall) / (precision + recall);
+				if (f1 > bestF1) {
+					bestF1 = f1;
+				}
+			}
+
+			overlappingReference.clear();
+
+			values[i] = bestF1;
+			minimumValue = std::min(bestF1, minimumValue);
+			maximumValue = std::max(bestF1, maximumValue);
+			unweightedAverage += bestF1;
+			weightedAverage += bestF1 * Csets[i].size();
+		}
+	}
+
+	handler.assureRunning();
+
+	unweightedAverage /= numClusters;
+	weightedAverage /= numMemberships;
+
+	hasRun = true;
+}
+
+}

--- a/networkit/cpp/community/CoverF1Similarity.h
+++ b/networkit/cpp/community/CoverF1Similarity.h
@@ -1,0 +1,57 @@
+#ifndef COVERF1SIMILARITY_H_
+#define COVERF1SIMILARITY_H_
+
+#include "LocalCoverEvaluation.h"
+
+namespace NetworKit {
+
+/**
+ * @ingroup community
+ * Compare a given cover to a reference cover using the F1 measure.
+ * This is a typical similarity measure used to compare the found
+ * overlapping community structure to a ground truth community
+ * structure. Each cluster is compared to the best-matching reference
+ * cluster (in terms of highest F1 score). A value of 1 indicates
+ * perfect agreement while a while of 0 indicates complete
+ * disagreement. An example where this measure is used is the
+ * following paper:
+ *
+ * Alessandro Epasto, Silvio Lattanzi, and Renato Paes
+ * Leme. 2017. Ego-Splitting Framework: from Non-Overlapping to
+ * Overlapping Clusters. In Proceedings of the 23rd ACM SIGKDD
+ * International Conference on Knowledge Discovery and Data Mining
+ * (KDD '17). ACM, New York, NY, USA, 145-154. DOI:
+ * https://doi.org/10.1145/3097983.3098054
+ */
+class CoverF1Similarity : public LocalCoverEvaluation {
+public:
+	/**
+	 * Initialize the cover F1 similarity.
+	 *
+	 * @param G The graph on which the evaluation is performed.
+	 * @param C The cover that shall be evaluated.
+	 * @param reference The reference cover to which @a C shall be compared.
+	 */
+	CoverF1Similarity(const Graph& G, const Cover& C, const Cover& reference);
+
+	/**
+	 * Execute the algorithm.
+	 */
+	virtual void run() override;
+
+	/**
+	 * @return false - smaller is not better, larger values indicate better matching clusters.
+	 */
+	virtual bool isSmallBetter() const override { return false; }
+
+	/**
+	 * @return false - this algorithm has not been parallelized.
+	 */
+	virtual bool isParallel() const override { return false; }
+private:
+	const Cover &reference;
+};
+
+}
+
+#endif

--- a/networkit/cpp/community/test/CommunityGTest.cpp
+++ b/networkit/cpp/community/test/CommunityGTest.cpp
@@ -38,6 +38,7 @@
 #include "../PartitionFragmentation.h"
 #include "../../generators/ClusteredRandomGraphGenerator.h"
 #include "../../generators/ErdosRenyiGenerator.h"
+#include "../CoverF1Similarity.h"
 
 namespace NetworKit {
 
@@ -674,5 +675,48 @@ TEST_F(CommunityGTest, testPartitionFragmentation) {
 	EXPECT_DOUBLE_EQ(0.9, frag3.getWeightedAverage());
 }
 
+TEST_F(CommunityGTest, testCoverF1Similarity) {
+	count n = 20;
+	Graph G(n);
+
+	Cover C(n);
+	C.setUpperBound(3);
+	Cover ref(n);
+	ref.setUpperBound(3);
+
+	// 0: perfect overlap
+	for (node u = 0; u < 10; ++u) {
+		C.addToSubset(0, u);
+		ref.addToSubset(1, u);
+	}
+
+	for (node u = 0; u < 11; ++u) {
+		ref.addToSubset(0, u);
+	}
+
+	// 1: two node overlap with 0, one node overlap with 1
+	for (node u = 9; u < 19; ++u) {
+		C.addToSubset(1, u);
+	}
+
+	// 2: no overlap
+	for (node u = 11; u < 20; ++u) {
+		C.addToSubset(2, u);
+	}
+
+	CoverF1Similarity sim(G, C, ref);
+	sim.run();
+
+	EXPECT_DOUBLE_EQ(1.0, sim.getMaximumValue());
+	EXPECT_DOUBLE_EQ(0.0, sim.getMinimumValue());
+	EXPECT_DOUBLE_EQ(1.0, sim.getValue(0));
+	const double pre = 2.0 / 11.0;
+	const double re = 2.0 / 10.0;
+	const double f1 = 2.0 * (pre * re) / (pre + re);
+	EXPECT_DOUBLE_EQ(f1, sim.getValue(1));
+	EXPECT_DOUBLE_EQ(0.0, sim.getValue(2));
+	EXPECT_DOUBLE_EQ((1.0 + f1) / 3.0, sim.getUnweightedAverage());
+	EXPECT_DOUBLE_EQ((1.0 * 10.0 + f1 * 10.0) / 29.0, sim.getWeightedAverage());
+}
 
 } /* namespace NetworKit */


### PR DESCRIPTION
This adds an algorithm to compare two covers using the F1 score. This is a typical similarity measure used to compare the found overlapping community structure to a ground truth community structure. Each cluster is compared to the best-matching reference cluster (in terms of highest F1 score). A value of 1 indicates perfect agreement while a while of 0 indicates complete disagreement. An example where this measure is used is the following paper:

Alessandro Epasto, Silvio Lattanzi, and Renato Paes Leme. 2017. Ego-Splitting Framework: from Non-Overlapping to Overlapping Clusters. In Proceedings of the 23rd ACM SIGKDD International Conference on Knowledge Discovery and Data Mining (KDD '17). ACM, New York, NY, USA, 145-154. DOI: https://doi.org/10.1145/3097983.3098054

Note that this breaks with the tradition of having dissimilarity measures implementing `DissimilarityMeasure` with a basically empty constructor and a `getDissimilarity()`-method that does all the computation. Instead, this class implements the `LocalCoverEvaluation` interface. This is for three reasons:

* Dissimilarity is not very intuitive as in the literature all of these measures are considered as similarities.
* The interface of the dissimilarity measures does not follow the `Algorithm` interface in NetworKit as they are very old.
* Following the `LocalCoverEvaluation` interface makes it easy to generate more fine-grained evaluations by inspecting the F1 score of individual clusters. Further, this class inherits from `Algorithm`.

If you do not like the interface I'm also willing to adapt the algorithm to the traditional interface e.g. by adding a wrapper class that implements `DissimilarityMeasure`.