### PR TITLE
Add missing dependency to GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ if (NETWORKIT_BUILD_TESTS)
 	else()
 		add_library(networkit_gtest_main STATIC networkit/cpp/Unittests-X.cpp)
 		target_link_libraries(networkit_gtest_main
+				PUBLIC gtest
 				PRIVATE networkit_auxiliary)
 	endif()
 endif()


### PR DESCRIPTION
This PR adds the missing dependency of `networkit_gtest_main` to `gtest`.