### PR TITLE
Travis: switch to xenial Linux distribution and Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ matrix:
     - name: Linux, modern GCC
       env: CC=gcc-8 CXX=g++-8
       os: linux
+      dist: xenial
       addons: &gcc8
         apt:
           sources:
@@ -85,11 +86,12 @@ matrix:
           packages:
             - g++-8
             - python3-pip
-            - python3.4-venv
+            - python3.5-venv
 
     - name: Linux, legacy GCC 4.9
       env: CC=gcc-4.9 CXX=g++-4.9
       os: linux
+      dist: xenial
       sudo: false
       addons:
         apt:
@@ -99,11 +101,12 @@ matrix:
             - cmake
             - g++-4.9
             - python3-pip
-            - python3.4-venv
+            - python3.5-venv
 
     - name: Linux, legacy Clang 3.8
       env: CC="clang-3.8" CXX="clang++-3.8"
       os: linux
+      dist: xenial
       sudo: false
       addons:
         apt:
@@ -114,12 +117,13 @@ matrix:
             - clang-3.8
             - libiomp-dev
             - python3-pip
-            - python3.4-venv
+            - python3.5-venv
 
     # Test more exotic builds only on Linux.
     - name: "Linux, modern GCC: Core build, debugging"
       env: CC=gcc-8 CXX=g++-8
       os: linux
+      dist: xenial
       addons: *gcc8
       script:
         - $CXX --version
@@ -131,6 +135,7 @@ matrix:
     - name: "Linux, modern GCC: Core build, non-monolithic"
       env: CC=gcc-8 CXX=g++-8
       os: linux
+      dist: xenial
       addons: *gcc8
       script:
         - $CXX --version
@@ -143,6 +148,7 @@ matrix:
     - name: C++14 conformance
       env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=14
       os: linux
+      dist: xenial
       addons: *gcc8
       script: &script_cpp_only
         - $CXX --version
@@ -154,12 +160,14 @@ matrix:
     - name: C++17 conformance
       env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=17
       os: linux
+      dist: xenial
       addons: *gcc8
       script: *script_cpp_only
 
     - name: Documentation only
       env: CC=gcc-8 CXX=g++-8
       os: linux
+      dist: xenial
       addons:
         apt:
           sources:
@@ -167,7 +175,7 @@ matrix:
           packages:
             - g++-8
             - python3-pip
-            - python3.4-venv
+            - python3.5-venv
             - doxygen
       script:
         - set -e


### PR DESCRIPTION
Switched to xenial distribution and Python 3.5 for all Linux builds on Travis.