### PR TITLE
Linking tlx to networkit python build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,9 @@ if(NETWORKIT_PYTHON)
 		set_target_properties(_NetworKit PROPERTIES
 				INSTALL_RPATH "$ORIGIN")
 	endif()
+
+    target_link_libraries(_NetworKit PRIVATE tlx)
+
 	install(TARGETS _NetworKit
 			LIBRARY DESTINATION ${NETWORKIT_LIB_DEST})
 endif()


### PR DESCRIPTION
Tlx files could not be linked to the Python build if they were included from NetworKit `.hpp` files.
This fixes the issue.