### PR TITLE
Removed neighbors() method from Graph and fixed affected classes

### DIFF
--- a/include/networkit/centrality/GroupDegree.hpp
+++ b/include/networkit/centrality/GroupDegree.hpp
@@ -64,7 +64,7 @@ public:
 	count scoreOfGroup(const std::vector<node> &group) const;
 
 protected:
-	Graph G;
+	const Graph &G;
 	const count k;
 	const bool countGroupNodes;
 	count n;

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -445,10 +445,29 @@ class Graph final {
     /**
      * Class to iterate over the in/out neighbors of a node.
      */
-    class NeighborIterator
-        : public std::iterator<std::forward_iterator_tag, const node> {
+    class NeighborIterator {
 
       public:
+        // The value type of the neighbors (i.e. nodes). Returned by
+        // operator*().
+        typedef node value_type;
+
+        // Reference to the value_type, required by STL.
+        typedef value_type &reference;
+
+        // Pointer to the value_type, required by STL.
+        typedef value_type *pointer;
+
+        // STL iterator category.
+        typedef std::forward_iterator_tag iterator_category;
+
+        // Signed integer type of the result of subtracting two pointers,
+        // required by STL.
+        typedef ptrdiff_t difference_type;
+
+        // Own type.
+        typedef NeighborIterator self;
+
         NeighborIterator(const Graph &G, node u,
                          std::vector<node>::const_iterator nodesIter)
             : G(G), u(u), nIter(nodesIter) {}
@@ -495,11 +514,29 @@ class Graph final {
      * Class to iterate over the in/out neighbors of a node including the edge
      * weights. Values are std::pair<node, edgeweight>.
      */
-    class NeighborWeightIterator
-        : public std::iterator<std::forward_iterator_tag,
-                               const std::pair<node, edgeweight>> {
+    class NeighborWeightIterator {
 
       public:
+        // The value type of the neighbors (i.e. nodes). Returned by
+        // operator*().
+        typedef std::pair<node, edgeweight> value_type;
+
+        // Reference to the value_type, required by STL.
+        typedef value_type &reference;
+
+        // Pointer to the value_type, required by STL.
+        typedef value_type *pointer;
+
+        // STL iterator category.
+        typedef std::forward_iterator_tag iterator_category;
+
+        // Signed integer type of the result of subtracting two pointers,
+        // required by STL.
+        typedef ptrdiff_t difference_type;
+
+        // Own type.
+        typedef NeighborWeightIterator self;
+
         NeighborWeightIterator(
             const Graph &G, node u, std::vector<node>::const_iterator nodesIter,
             std::vector<edgeweight>::const_iterator weightIter)
@@ -525,7 +562,7 @@ class Graph final {
             return prev;
         }
 
-        NeighborWeightIterator operator--(int){
+        NeighborWeightIterator operator--(int) {
             --nIter;
             --wIter;
             return *this;

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1191,20 +1191,12 @@ class Graph final {
     std::vector<std::pair<node, node>> edges() const;
 
     /**
-     * Get list of neighbors of @a u.
-     *
-     * @param u Node.
-     * @return List of neighbors of @a u.
-     */
-    std::vector<node> neighbors(node u) const;
-
-    /**
      * Get an iterable range over the neighbors of @a.
      *
      * @param u Node.
      * @return Iterator range over the neighbors of @a.
      */
-    NeighborRange<false> neighborRange(node u) {
+    NeighborRange<false> neighborRange(node u) const {
         assert(exists[u]);
         return NeighborRange<false>(*this, u);
     }
@@ -1217,7 +1209,7 @@ class Graph final {
      * @return Iterator range over pairs of neighbors of @a and corresponding
      * edge weights.
      */
-    NeighborWeightRange<false> weightNeighborRange(node u) {
+    NeighborWeightRange<false> weightNeighborRange(node u) const {
         assert(isWeighted());
         assert(exists[u]);
         return NeighborWeightRange<false>(*this, u);
@@ -1229,7 +1221,7 @@ class Graph final {
      * @param u Node.
      * @return Iterator range over pairs of in-neighbors of @a.
      */
-    NeighborRange<true> inNeighborRange(node u) {
+    NeighborRange<true> inNeighborRange(node u) const {
         assert(isDirected());
         assert(exists[u]);
         return NeighborRange<true>(*this, u);
@@ -1243,7 +1235,7 @@ class Graph final {
      * @return Iterator range over pairs of in-neighbors of @a and corresponding
      * edge weights.
      */
-    NeighborWeightRange<true> weightInNeighborRange(node u) {
+    NeighborWeightRange<true> weightInNeighborRange(node u) const {
         assert(isDirected() && isWeighted());
         assert(exists[u]);
         return NeighborWeightRange<true>(*this, u);

--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -445,11 +445,10 @@ class Graph final {
     /**
      * Class to iterate over the in/out neighbors of a node.
      */
-    class NeighborIterator {
+    class NeighborIterator
+        : public std::iterator<std::forward_iterator_tag, const node> {
 
       public:
-        typedef std::forward_iterator_tag iteratorCategory;
-
         NeighborIterator(const Graph &G, node u,
                          std::vector<node>::const_iterator nodesIter)
             : G(G), u(u), nIter(nodesIter) {}
@@ -465,11 +464,22 @@ class Graph final {
             return *this;
         }
 
-        bool operator==(const NeighborIterator &rhs) {
+        NeighborIterator operator--() {
+            auto prev = *this;
+            --nIter;
+            return prev;
+        }
+
+        NeighborIterator operator--(int) {
+            --nIter;
+            return *this;
+        }
+
+        bool operator==(const NeighborIterator &rhs) const {
             return nIter == rhs.nIter;
         }
 
-        bool operator!=(const NeighborIterator &rhs) {
+        bool operator!=(const NeighborIterator &rhs) const {
             return nIter != rhs.nIter;
         }
 
@@ -485,11 +495,11 @@ class Graph final {
      * Class to iterate over the in/out neighbors of a node including the edge
      * weights. Values are std::pair<node, edgeweight>.
      */
-    class NeighborWeightIterator {
+    class NeighborWeightIterator
+        : public std::iterator<std::forward_iterator_tag,
+                               const std::pair<node, edgeweight>> {
 
       public:
-        typedef std::forward_iterator_tag iteratorCategory;
-
         NeighborWeightIterator(
             const Graph &G, node u, std::vector<node>::const_iterator nodesIter,
             std::vector<edgeweight>::const_iterator weightIter)
@@ -508,11 +518,24 @@ class Graph final {
             return *this;
         }
 
-        bool operator==(const NeighborWeightIterator &rhs) {
+        NeighborWeightIterator operator--() {
+            auto prev = *this;
+            --nIter;
+            --wIter;
+            return prev;
+        }
+
+        NeighborWeightIterator operator--(int){
+            --nIter;
+            --wIter;
+            return *this;
+        }
+
+        bool operator==(const NeighborWeightIterator &rhs) const {
             return nIter == rhs.nIter && wIter == rhs.wIter;
         }
 
-        bool operator!=(const NeighborWeightIterator &rhs) {
+        bool operator!=(const NeighborWeightIterator &rhs) const {
             return nIter != rhs.nIter || wIter != rhs.wIter;
         }
 
@@ -535,13 +558,13 @@ class Graph final {
       public:
         NeighborRange(const Graph &G, node u) : G(G), u(u){};
 
-        NeighborIterator begin() {
+        NeighborIterator begin() const {
             if (InEdges)
                 return NeighborIterator(G, u, G.inEdges[u].begin());
             return NeighborIterator(G, u, G.outEdges[u].begin());
         }
 
-        NeighborIterator end() {
+        NeighborIterator end() const {
             if (InEdges)
                 return NeighborIterator(G, u, G.inEdges[u].end());
             return NeighborIterator(G, u, G.outEdges[u].end());
@@ -562,7 +585,7 @@ class Graph final {
       public:
         NeighborWeightRange(const Graph &G, node u) : G(G), u(u){};
 
-        NeighborWeightIterator begin() {
+        NeighborWeightIterator begin() const {
             if (InEdges)
                 return NeighborWeightIterator(G, u, G.inEdges[u].begin(),
                                               G.inEdgeWeights[u].begin());
@@ -570,7 +593,7 @@ class Graph final {
                                           G.outEdgeWeights[u].begin());
         }
 
-        NeighborWeightIterator end() {
+        NeighborWeightIterator end() const {
             if (InEdges)
                 return NeighborWeightIterator(G, u, G.inEdges[u].end(),
                                               G.inEdgeWeights[u].end());
@@ -1189,6 +1212,14 @@ class Graph final {
      * @return List of edges as node pairs.
      */
     std::vector<std::pair<node, node>> edges() const;
+
+    /**
+     * Get list of neighbors of @a u.
+     *
+     * @param u Node.
+     * @return List of neighbors of @a u.
+     */
+    [[deprecated]] std::vector<node> neighbors(node u) const;
 
     /**
      * Get an iterable range over the neighbors of @a.

--- a/networkit/cpp/centrality/GroupDegree.cpp
+++ b/networkit/cpp/centrality/GroupDegree.cpp
@@ -58,10 +58,7 @@ void GroupDegree::run() {
 		updateGroup();
 	}
 
-	std::vector<node> neighbors = G.neighbors(group.back());
-#pragma omp parallel for
-	for (omp_index i = 0; i < neighbors.size(); ++i) {
-		node u = neighbors[i];
+	for (node u : G.neighborRange(group.back())) {
 		reachable[u] = true;
 	}
 
@@ -79,7 +76,6 @@ void GroupDegree::updateGroup() {
 void GroupDegree::updateQueue() {
 	node lastAdded = group.back();
 	std::fill(affected.begin(), affected.end(), false);
-	std::vector<node> neighbors = G.neighbors(lastAdded);
 
 	auto processNode = [&](node v) {
 		if (!inGroup[v]) {
@@ -87,9 +83,7 @@ void GroupDegree::updateQueue() {
 		}
 	};
 
-	// If executed in parallel, this loop leads to errors.
-	for (omp_index i = 0; i < static_cast<omp_index>(neighbors.size()); ++i) {
-		node u = neighbors[i];
+	for (node u : G.neighborRange(lastAdded)) {
 		if (!inGroup[u] && !reachable[u]) {
 			affected[u] = true;
 			reachable[u] = true;

--- a/networkit/cpp/centrality/KadabraBetweenness.cpp
+++ b/networkit/cpp/centrality/KadabraBetweenness.cpp
@@ -541,9 +541,9 @@ void SpSampler::backtrackPath(const node u, const node v, const node start,
 
 	path.push_back(start);
 	randomPred = Aux::Random::integer(totWeight - 1);
-	assert((pred.neighbors(start)).size() > 0);
+	assert((pred.degree(start)) > 0);
 
-	for (node t : pred.neighbors(start)) {
+	for (node t : pred.neighborRange(start)) {
 		w = t;
 		curPred += nPaths[v];
 		if (curPred > randomPred) {

--- a/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
+++ b/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
@@ -17,7 +17,10 @@ TEST_F(MaximalCliquesGTest, testMaximalCliques) {
 	Graph G = reader.read("input/hep-th.graph");
 
 	node seed = 2;
-	auto sn = G.neighbors(seed);
+    std::vector<node> sn;
+    sn.reserve(G.degree(seed));
+    for (node u : G.neighborRange(seed))
+        sn.push_back(u);
 	auto sneighbors = std::unordered_set<node>(sn.begin(), sn.end());
 	sneighbors.insert(seed);
 	auto subG = G.subgraphFromNodes(sneighbors);

--- a/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
+++ b/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
@@ -17,10 +17,7 @@ TEST_F(MaximalCliquesGTest, testMaximalCliques) {
 	Graph G = reader.read("input/hep-th.graph");
 
 	node seed = 2;
-    std::vector<node> sn;
-    sn.reserve(G.degree(seed));
-    for (node u : G.neighborRange(seed))
-        sn.push_back(u);
+	std::vector<node> sn(G.neighborRange(seed).begin(), G.neighborRange(seed).end());
 	auto sneighbors = std::unordered_set<node>(sn.begin(), sn.end());
 	sneighbors.insert(seed);
 	auto subG = G.subgraphFromNodes(sneighbors);

--- a/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
+++ b/networkit/cpp/clique/test/MaximalCliquesGTest.cpp
@@ -17,7 +17,8 @@ TEST_F(MaximalCliquesGTest, testMaximalCliques) {
 	Graph G = reader.read("input/hep-th.graph");
 
 	node seed = 2;
-	std::vector<node> sn(G.neighborRange(seed).begin(), G.neighborRange(seed).end());
+	std::vector<node> sn(G.neighborRange(seed).begin(),
+						 G.neighborRange(seed).end());
 	auto sneighbors = std::unordered_set<node>(sn.begin(), sn.end());
 	sneighbors.insert(seed);
 	auto subG = G.subgraphFromNodes(sneighbors);

--- a/networkit/cpp/community/SampledGraphStructuralRandMeasure.cpp
+++ b/networkit/cpp/community/SampledGraphStructuralRandMeasure.cpp
@@ -31,10 +31,8 @@ double SampledGraphStructuralRandMeasure::getDissimilarity(const Graph& G, const
 	while (nSamples < maxSamples) {
 		node u = Aux::Random::integer(z - 1);
 		if (G.hasNode(u) && (G.degree(u) > 0)) {
-            std::vector<node> neighbors;
-            neighbors.reserve(G.degree(u));
-            for (node x : G.neighborRange(u))
-                neighbors.push_back(x);
+			std::vector<node> neighbors(G.neighborRange(u).begin(),
+										G.neighborRange(u).end());
 			index i = Aux::Random::integer(neighbors.size() - 1);
 			node v = neighbors.at(i);
 			assert (G.hasEdge(u, v));

--- a/networkit/cpp/community/SampledGraphStructuralRandMeasure.cpp
+++ b/networkit/cpp/community/SampledGraphStructuralRandMeasure.cpp
@@ -31,7 +31,10 @@ double SampledGraphStructuralRandMeasure::getDissimilarity(const Graph& G, const
 	while (nSamples < maxSamples) {
 		node u = Aux::Random::integer(z - 1);
 		if (G.hasNode(u) && (G.degree(u) > 0)) {
-			auto neighbors = G.neighbors(u);
+            std::vector<node> neighbors;
+            neighbors.reserve(G.degree(u));
+            for (node x : G.neighborRange(u))
+                neighbors.push_back(x);
 			index i = Aux::Random::integer(neighbors.size() - 1);
 			node v = neighbors.at(i);
 			assert (G.hasEdge(u, v));

--- a/networkit/cpp/components/BiconnectedComponents.cpp
+++ b/networkit/cpp/components/BiconnectedComponents.cpp
@@ -60,7 +60,7 @@ void BiconnectedComponents::run() {
 
       bool allVisited = true;
 
-      for (node neighbor : G.neighbors(u)) {
+      for (node neighbor : G.neighborRange(u)) {
         if (!visited[neighbor]) {
           allVisited = false;
           visit(neighbor);

--- a/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
@@ -49,7 +49,10 @@ TEST_F(BiconnectedComponentsGTest, testBiconnectedComponents) {
 		count nComps = cc.numberOfComponents();
 		for (node v : component) {
 
-			std::vector<node> neighbors = G.neighbors(v);
+			std::vector<node> neighbors;
+            neighbors.reserve(G.degree(v));
+            for (node w : G.neighborRange(v))
+                neighbors.push_back(w);
 			// Simulating node removal
 			for (node w : neighbors) {
 				G.removeEdge(v, w);

--- a/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/BiconnectedComponentsGTest.cpp
@@ -49,10 +49,8 @@ TEST_F(BiconnectedComponentsGTest, testBiconnectedComponents) {
 		count nComps = cc.numberOfComponents();
 		for (node v : component) {
 
-			std::vector<node> neighbors;
-            neighbors.reserve(G.degree(v));
-            for (node w : G.neighborRange(v))
-                neighbors.push_back(w);
+			std::vector<node> neighbors(G.neighborRange(v).begin(),
+										G.neighborRange(v).end());
 			// Simulating node removal
 			for (node w : neighbors) {
 				G.removeEdge(v, w);

--- a/networkit/cpp/distance/Volume.cpp
+++ b/networkit/cpp/distance/Volume.cpp
@@ -20,7 +20,7 @@ std::unordered_map<node, double> Volume::nodesWithinDistance(const Graph &G, dou
 	while (!msToCheck.empty()) {
 		std::vector<node> msToCheckNew;
 		for (auto &m : msToCheck) {
-			for (auto &m2 : G.neighbors(m)) {
+			for (node m2 : G.neighborRange(m)) {
 				r2 = ms[m] + G.weight(m, m2);
 				if (ms.count(m2) == 0) {
 					if (r2 <= r) {

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -955,6 +955,13 @@ std::vector<std::pair<node, node>> Graph::edges() const {
 	return edges;
 }
 
+std::vector<node> Graph::neighbors(node u) const {
+	std::vector<node> neighbors;
+	neighbors.reserve(degree(u));
+	this->forNeighborsOf(u, [&](node v) { neighbors.push_back(v); });
+	return neighbors;
+}
+
 Graph Graph::transpose() const {
 	if (directed == false) {
 		throw std::runtime_error("The transpose of an undirected graph is "

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -955,13 +955,6 @@ std::vector<std::pair<node, node>> Graph::edges() const {
 	return edges;
 }
 
-std::vector<node> Graph::neighbors(node u) const {
-	std::vector<node> neighbors;
-	neighbors.reserve(degree(u));
-	this->forNeighborsOf(u, [&](node v) { neighbors.push_back(v); });
-	return neighbors;
-}
-
 Graph Graph::transpose() const {
 	if (directed == false) {
 		throw std::runtime_error("The transpose of an undirected graph is "

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -823,7 +823,7 @@ TEST_P(GraphGTest, testRemoveAllEdges) {
 	EXPECT_EQ(g.numberOfEdges(), 0);
 	EXPECT_EQ(g.edges().size(), 0);
 	for (node u : g.nodes()) {
-		EXPECT_EQ(g.neighbors(u).size(), 0);
+		EXPECT_EQ(g.degree(u), 0);
 		EXPECT_EQ(g.degree(u), 0);
 	}
 
@@ -832,7 +832,7 @@ TEST_P(GraphGTest, testRemoveAllEdges) {
 	EXPECT_EQ(g.numberOfEdges(), 0);
 	EXPECT_EQ(g.edges().size(), 0);
 	for (node u : g.nodes()) {
-		EXPECT_EQ(g.neighbors(u).size(), 0);
+		EXPECT_EQ(g.degree(u), 0);
 		EXPECT_EQ(g.degree(u), 0);
 		EXPECT_EQ(g.degreeIn(u), 0);
 	}
@@ -1195,22 +1195,6 @@ TEST_P(GraphGTest, testNodes) {
 	ASSERT_EQ(G.numberOfNodes(), nodes.size());
 	for (node v : nodes) {
 		ASSERT_TRUE(containsNode(v));
-	}
-}
-
-TEST_P(GraphGTest, testNeighbors) {
-	auto neighbors = this->Ghouse.neighbors(1);
-	auto containsNode = [&neighbors](node v) {
-		return std::find(neighbors.begin(), neighbors.end(), v) != neighbors.end();
-	};
-	if (this->Ghouse.isDirected()) {
-		ASSERT_TRUE(containsNode(0));
-		ASSERT_TRUE(containsNode(4));
-	} else {
-		ASSERT_TRUE(containsNode(0));
-		ASSERT_TRUE(containsNode(2));
-		ASSERT_TRUE(containsNode(3));
-		ASSERT_TRUE(containsNode(4));
 	}
 }
 

--- a/networkit/cpp/linkprediction/NeighborhoodUtility.cpp
+++ b/networkit/cpp/linkprediction/NeighborhoodUtility.cpp
@@ -10,14 +10,8 @@
 namespace NetworKit {
 
 std::pair<std::vector<node>, std::vector<node>> NeighborhoodUtility::getSortedNeighborhoods(const Graph& G, node u, node v) {
-  std::vector<node> uNeighbors;
-  std::vector<node> vNeighbors;
-  uNeighbors.reserve(G.degree(u));
-  vNeighbors.reserve(G.degree(v));
-  for (node uu : G.neighborRange(u))
-      uNeighbors.push_back(uu);
-  for (node vv : G.neighborRange(v))
-      vNeighbors.push_back(vv);
+  std::vector<node> uNeighbors(G.neighborRange(u).begin(), G.neighborRange(u).end());
+  std::vector<node> vNeighbors(G.neighborRange(v).begin(), G.neighborRange(v).end());
   // We have no guarantee that the neighbor-vectors are sorted so we have to
   // sort them in order for set-functions to work properly.
   std::sort(uNeighbors.begin(), uNeighbors.end());

--- a/networkit/cpp/linkprediction/NeighborhoodUtility.cpp
+++ b/networkit/cpp/linkprediction/NeighborhoodUtility.cpp
@@ -10,8 +10,14 @@
 namespace NetworKit {
 
 std::pair<std::vector<node>, std::vector<node>> NeighborhoodUtility::getSortedNeighborhoods(const Graph& G, node u, node v) {
-  std::vector<node> uNeighbors = G.neighbors(u);
-  std::vector<node> vNeighbors = G.neighbors(v);
+  std::vector<node> uNeighbors;
+  std::vector<node> vNeighbors;
+  uNeighbors.reserve(G.degree(u));
+  vNeighbors.reserve(G.degree(v));
+  for (node uu : G.neighborRange(u))
+      uNeighbors.push_back(uu);
+  for (node vv : G.neighborRange(v))
+      vNeighbors.push_back(vv);
   // We have no guarantee that the neighbor-vectors are sorted so we have to
   // sort them in order for set-functions to work properly.
   std::sort(uNeighbors.begin(), uNeighbors.end());


### PR DESCRIPTION
This removes the `neighbors(v)` method from the graph class; the method creates a copy of the `outEdges[v]` vector which is not an efficient way to iterate over neighbors.

Declared the getter methods of the neighbor iterators of the `Graph` class as `const` so they can be also be used by const refs of Graph objects.