### PR TITLE
Add macOS builds with llvm 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,7 @@ matrix:
           packages:
             - llvm@8
             - libomp
-
-    - name: macOS 10.13, llvm 7
-      env: CC=/usr/local/opt/llvm@7/bin/clang
-      env: CXX=/usr/local/opt/llvm@7/bin/clang++
-      os: osx
-      osx_image: xcode10.1
-      sudo: false
-      addons:
-        homebrew:
-          packages:
-            - llvm@7
-            - libomp
+          update: true
 
     - name: macOS 10.13, GCC 8
       env: CC=/usr/local/opt/gcc@8/bin/gcc-8
@@ -57,20 +46,6 @@ matrix:
         homebrew:
           packages:
             - libomp
-
-    - name: macOS 10.12, llvm 8
-      env: CC=/usr/local/opt/llvm@8/bin/clang
-      env: CXX=/usr/local/opt/llvm@8/bin/clang++
-      os: osx
-      osx_image: xcode9.2
-      sudo: false
-      addons:
-        homebrew:
-          packages:
-            - llvm@8
-            - libomp
-            - python
-          update: true
 
     - name: macOS 10.12, llvm 7
       env: CC=/usr/local/opt/llvm@7/bin/clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ env:
 
 matrix:
   include:
+    - name: macOS 10.13, llvm 8
+      env: CC=/usr/local/opt/llvm@8/bin/clang
+      env: CXX=/usr/local/opt/llvm@8/bin/clang++
+      os: osx
+      osx_image: xcode10.1
+      sudo: false
+      addons:
+        homebrew:
+          packages:
+            - llvm@8
+            - libomp
+
     - name: macOS 10.13, llvm 7
       env: CC=/usr/local/opt/llvm@7/bin/clang
       env: CXX=/usr/local/opt/llvm@7/bin/clang++
@@ -45,6 +57,20 @@ matrix:
         homebrew:
           packages:
             - libomp
+
+    - name: macOS 10.12, llvm 8
+      env: CC=/usr/local/opt/llvm@8/bin/clang
+      env: CXX=/usr/local/opt/llvm@8/bin/clang++
+      os: osx
+      osx_image: xcode9.2
+      sudo: false
+      addons:
+        homebrew:
+          packages:
+            - llvm@8
+            - libomp
+            - python
+          update: true
 
     - name: macOS 10.12, llvm 7
       env: CC=/usr/local/opt/llvm@7/bin/clang


### PR DESCRIPTION
This adds two new builds to travis: macOS 10.12/13 with the newly released llvm 8.