### PR TITLE
fix/closeness

### DIFF
--- a/include/networkit/centrality/Closeness.hpp
+++ b/include/networkit/centrality/Closeness.hpp
@@ -12,60 +12,62 @@
 
 namespace NetworKit {
 
-enum ClosenessVariant { standard = 0, generalized = 1};
+enum ClosenessVariant { standard = 0, generalized = 1 };
 
 /**
  * @ingroup centrality
  */
 class Closeness : public Centrality {
 
-public:
-	/**
-	 * Constructs the Closeness class for the given Graph @a G. If the closeness
-	 * scores should be normalized, then set @a normalized to <code>true</code>.
-	 * The run() method takes O(nm) time, where n is the number of nodes and m is
-	 * the number of edges of the graph. NOTICE: the graph has to be connected.
-	 *
-	 * @param G The graph.
-	 * @param normalized Set this parameter to <code>false</code> if scores should
-	 * not be normalized into an interval of [0, 1]. Normalization only for
-	 * unweighted graphs.
-	 *
-	 */
-	Closeness(const Graph &G, bool normalized,
-	          const ClosenessVariant variant = ClosenessVariant::standard);
+  public:
+    /**
+     * Constructs the Closeness class for the given Graph @a G. If the closeness
+     * scores should be normalized, then set @a normalized to <code>true</code>.
+     * The run() method takes O(nm) time, where n is the number of nodes and m
+     * is the number of edges of the graph. NOTICE: the graph has to be
+     * connected.
+     *
+     * @param G The graph.
+     * @param normalized Set this parameter to <code>false</code> if scores
+     * should not be normalized into an interval of [0, 1]. Normalization only
+     * for unweighted graphs.
+     *
+     */
+    Closeness(const Graph &G, bool normalized,
+              const ClosenessVariant variant = ClosenessVariant::standard);
 
-	/**
-	 * Old constructor, we keep it for backward compatibility. It computes the
-	 * standard variant of the closenes.
-	 *
-	 * @param G The graph.
-	 * @param normalized Set this parameter to <code>false</code> if scores should
-	 * not be normalized into an interval of [0, 1]. Normalization only for
-	 * unweighted graphs.
-	 * @param checkConnectedness turn this off if you know the graph is connected.
-	 *
-	 */
-	Closeness(const Graph &G, bool normalized = true,
-	          bool checkConnectedness = true);
+    /**
+     * Old constructor, we keep it for backward compatibility. It computes the
+     * standard variant of the closenes.
+     *
+     * @param G The graph.
+     * @param normalized Set this parameter to <code>false</code> if scores
+     * should not be normalized into an interval of [0, 1]. Normalization only
+     * for unweighted graphs.
+     * @param checkConnectedness turn this off if you know the graph is
+     * connected.
+     *
+     */
+    Closeness(const Graph &G, bool normalized = true,
+              bool checkConnectedness = true);
 
-	/**
-	 * Computes closeness cetrality on the graph passed in constructor.
-	 */
-	void run() override;
+    /**
+     * Computes closeness cetrality on the graph passed in constructor.
+     */
+    void run() override;
 
-	/*
-	 * Returns the maximum possible Closeness a node can have in a graph with the
-	 * same amount of nodes (=a star)
-	 */
-	double maximum() override;
+    /*
+     * Returns the maximum possible Closeness a node can have in a graph with
+     * the same amount of nodes (=a star)
+     */
+    double maximum() override;
 
-private:
-	const count n;
-	ClosenessVariant variant;
-	std::vector<count> reachableNodes;
+  private:
+    const count n;
+    ClosenessVariant variant;
+    std::vector<count> reachableNodes;
 
-	void checkConnectedComponents() const;
+    void checkConnectedComponents() const;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/BFS.hpp
+++ b/include/networkit/distance/BFS.hpp
@@ -15,31 +15,35 @@ namespace NetworKit {
 
 /**
  * @ingroup distance
- * The BFS class is used to do a breadth-first search on a Graph from a given source node.
+ * The BFS class is used to do a breadth-first search on a Graph from a given
+ * source node.
  */
 class BFS : public SSSP {
 
-friend class DynBFS;
+    friend class DynBFS;
 
-public:
-	/**
-	 * Constructs the BFS class for @a G and source node @a source.
-	 *
-	 * @param G The graph
-	 * @param source The source node of the breadth-first search
-	 * @param storePaths Paths are reconstructable and the number of paths is stored.
-	 * @param storeNodesSortedByDistance Store a vector of nodes ordered in increasing distance from the source.
-	 * @param target The target node.
-	 */
-	BFS(const Graph& G, node source, bool storePaths=true, bool storeNodesSortedByDistance=false, node target = none);
+  public:
+    /**
+     * Constructs the BFS class for @a G and source node @a source.
+     *
+     * @param G The graph
+     * @param source The source node of the breadth-first search
+     * @param storePaths Paths are reconstructable and the number of paths is
+     * stored.
+     * @param storeNodesSortedByDistance Store a vector of nodes ordered in
+     * increasing distance from the source.
+     * @param target The target node.
+     */
+    BFS(const Graph &G, node source, bool storePaths = true,
+        bool storeNodesSortedByDistance = false, node target = none);
 
-	/**
-	 * Breadth-first search from @a source.
-	 * @return Vector of unweighted distances from node @a source, i.e. the
-	 * length (number of edges) of the shortest path from @a source to any other node.
-	 */
-	virtual void run();
-
+    /**
+     * Breadth-first search from @a source.
+     * @return Vector of unweighted distances from node @a source, i.e. the
+     * length (number of edges) of the shortest path from @a source to any other
+     * node.
+     */
+    virtual void run();
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/BFS.hpp
+++ b/include/networkit/distance/BFS.hpp
@@ -45,6 +45,5 @@ class BFS : public SSSP {
      */
     virtual void run();
 };
-
 } /* namespace NetworKit */
 #endif /* BFS_H_ */

--- a/include/networkit/distance/Dijkstra.hpp
+++ b/include/networkit/distance/Dijkstra.hpp
@@ -8,7 +8,8 @@
 #ifndef DIJKSTRA_H_
 #define DIJKSTRA_H_
 
-#include "../auxiliary/PrioQueue.hpp"
+#include <tlx/container/d_ary_addressable_int_heap.hpp>
+
 #include "../graph/Graph.hpp"
 #include "SSSP.hpp"
 
@@ -43,6 +44,19 @@ class Dijkstra : public SSSP {
      * constructor.
      */
     virtual void run();
+
+  private:
+    struct Compare {
+      public:
+        Compare(const std::vector<double> &dist_) : dist(dist_) {}
+
+        bool operator()(node x, node y) const { return dist[x] < dist[y]; }
+
+      private:
+        const std::vector<double> &dist;
+    };
+
+    tlx::d_ary_addressable_int_heap<node, 2, Compare> heap;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/Dijkstra.hpp
+++ b/include/networkit/distance/Dijkstra.hpp
@@ -20,29 +20,29 @@ namespace NetworKit {
  */
 class Dijkstra : public SSSP {
 
-	friend class DynDijkstra;
-	friend class DynDijkstra2;
+    friend class DynDijkstra;
+    friend class DynDijkstra2;
 
-public:
-	/**
-	 * Creates the Dijkstra class for @a G and the source node @a source.
-	 *
-	 * @param G The graph.
-	 * @param source The source node.
-	 * @param storePaths Paths are reconstructable and the number of paths is
-	 *		  stored.
-	 * @param storeNodesSortedByDistance Store a vector of nodes ordered in
-	 *		  increasing distance from the source.
-	 * @param target The target node.
-	 */
-	Dijkstra(const Graph &G, node source, bool storePaths = true,
-					 bool storeNodesSortedByDistance = false, node target = none);
+  public:
+    /**
+     * Creates the Dijkstra class for @a G and the source node @a source.
+     *
+     * @param G The graph.
+     * @param source The source node.
+     * @param storePaths Paths are reconstructable and the number of paths is
+     *		  stored.
+     * @param storeNodesSortedByDistance Store a vector of nodes ordered in
+     *		  increasing distance from the source.
+     * @param target The target node.
+     */
+    Dijkstra(const Graph &G, node source, bool storePaths = true,
+             bool storeNodesSortedByDistance = false, node target = none);
 
-	/**
-	 * Performs the Dijkstra SSSP algorithm on the graph given in the
-	 * constructor.
-	 */
-	virtual void run();
+    /**
+     * Performs the Dijkstra SSSP algorithm on the graph given in the
+     * constructor.
+     */
+    virtual void run();
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/DynAPSP.hpp
+++ b/include/networkit/distance/DynAPSP.hpp
@@ -59,9 +59,10 @@ public:
 
 private:
 
-	const edgeweight infDist = std::numeric_limits<edgeweight>::max();
-	const edgeweight epsilon = 0.0000000001; //make sure that no legitimate edge weight is below that.
-	count visitedPairs = 0;
+  private:
+    const edgeweight epsilon =
+        0.0000000001; // make sure that no legitimate edge weight is below that.
+    count visitedPairs = 0;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -123,13 +123,43 @@ class SSSP : public Algorithm {
      */
     virtual std::vector<node> getNodesSortedByDistance(bool moveOut = true);
 
+    /**
+     * Returns the number of nodes reached by the source.
+     */
+    count getReachableNodes() const {
+        assureFinished();
+        return reachedNodes;
+    }
+
+    /**
+     * Sets a new source.
+     */
+    void setSource(node newSource) {
+        if (!G.hasNode(newSource))
+            throw std::runtime_error("Error: node not in the graph.");
+        source = newSource;
+    }
+
+    /**
+     * Returns the sum of distances from the source node node to the reached
+     * nodes.
+     */
+    count getSumOfDistances() const {
+        assureFinished();
+        return sumDist;
+    }
+
   protected:
     const Graph &G;
-    const node source;
+    node source;
     node target;
+    double sumDist;
+    count reachedNodes;
     std::vector<edgeweight> distances;
     std::vector<std::vector<node>> previous; // predecessors on shortest path
     std::vector<bigfloat> npaths;
+    std::vector<uint8_t> visited;
+    uint8_t ts;
 
     std::vector<node> nodesSortedByDistance;
 

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -11,9 +11,8 @@
 #include <set>
 #include <stack>
 
-#include "../graph/Graph.hpp"
 #include "../base/Algorithm.hpp"
-
+#include "../graph/Graph.hpp"
 
 namespace NetworKit {
 
@@ -21,145 +20,156 @@ namespace NetworKit {
  * @ingroup distance
  * Abstract base class for single-source shortest path algorithms.
  */
-class SSSP: public Algorithm {
+class SSSP : public Algorithm {
 
-public:
+  public:
+    /**
+     * Creates the SSSP class for @a G and source @a s.
+     *
+     * @param G The graph.
+     * @param source The source node.
+     * @param storePaths Paths are reconstructable and the number of paths is
+     * stored.
+     * @param storeNodesSortedByDistance Store a vector of nodes ordered in
+     * increasing distance from the source.
+     * @param target The target node.
+     */
+    SSSP(const Graph &G, node source, bool storePaths = true,
+         bool storeNodesSortedByDistance = false, node target = none);
 
-	/**
-	 * Creates the SSSP class for @a G and source @a s.
-	 *
-	 * @param G The graph.
-	 * @param source The source node.
-	 * @param storePaths Paths are reconstructable and the number of paths is stored.
-	 * @param storeNodesSortedByDistance Store a vector of nodes ordered in increasing distance from the source.
-	 * @param target The target node.
-	 */
-	SSSP(const Graph& G, node source, bool storePaths=true, bool storeNodesSortedByDistance=false, node target = none);
+    virtual ~SSSP() = default;
 
-	virtual ~SSSP() = default;
+    /** Computes the shortest paths from the source to all other nodes. */
+    virtual void run() = 0;
 
-	/** Computes the shortest paths from the source to all other nodes. */
-	virtual void run() = 0;
+    /**
+     * Returns a vector of weighted distances from the source node, i.e. the
+     * length of the shortest path from the source node to any other node.
+     *
+     * @param moveOut If set to true, the container will be moved out of the
+     * class instead of copying it; default=true.
+     * @return The weighted distances from the source node to any other node in
+     * the graph.
+     */
+    virtual std::vector<edgeweight> getDistances(bool moveOut = true);
 
-	/**
-	 * Returns a vector of weighted distances from the source node, i.e. the
- 	 * length of the shortest path from the source node to any other node.
- 	 *
- 	 * @param moveOut If set to true, the container will be moved out of the class instead of copying it; default=true.
- 	 * @return The weighted distances from the source node to any other node in the graph.
-	 */
-	virtual std::vector<edgeweight> getDistances(bool moveOut=true);
+    /**
+     * Returns the distance from the source node to @a t.
+     * @param  t Target node.
+     * @return The distance from source to target node @a t.
+     */
+    edgeweight distance(node t) const;
 
-	/**
-	 * Returns the distance from the source node to @a t.
-	 * @param  t Target node.
-	 * @return The distance from source to target node @a t.
-	 */
-	edgeweight distance(node t) const;
+    /**
+     * Returns the number of shortest paths between the source node and @a t.
+     * @param  t Target node.
+     * @return The number of shortest paths between source and @a t.
+     */
+    bigfloat numberOfPaths(node t) const;
 
-	/**
-	 * Returns the number of shortest paths between the source node and @a t.
-	 * @param  t Target node.
-	 * @return The number of shortest paths between source and @a t.
-	 */
-	bigfloat numberOfPaths(node t) const;
+    /**
+     * Returns the number of shortest paths between the source node and @a t
+     * as a double value. Workaround for Cython
+     * @param  t Target node.
+     * @return The number of shortest paths between source and @a t.
+     */
+    double _numberOfPaths(node t) const;
 
-	/**
-	 * Returns the number of shortest paths between the source node and @a t
-	 * as a double value. Workaround for Cython
-	 * @param  t Target node.
-	 * @return The number of shortest paths between source and @a t.
-	 */
-	double _numberOfPaths(node t) const;
+    /**
+     * Returns the predecessor nodes of @a t on all shortest paths from source
+     * to @a t.
+     * @param t Target node.
+     * @return The predecessors of @a t on all shortest paths from source to @a
+     * t.
+     */
+    std::vector<node> getPredecessors(node t) const;
 
-	/**
-	 * Returns the predecessor nodes of @a t on all shortest paths from source to @a t.
-	 * @param t Target node.
-	 * @return The predecessors of @a t on all shortest paths from source to @a t.
-	 */
-	std::vector<node> getPredecessors(node t) const;
+    /**
+     * Returns a shortest path from source to @a t and an empty path if source
+     * and @a t are not connected.
+     *
+     * @param t Target node.
+     * @param forward If @c true (default) the path is directed from source to
+     * @a t, otherwise the path is reversed.
+     * @return A shortest path from source to @a t or an empty path.
+     */
+    virtual std::vector<node> getPath(node t, bool forward = true) const;
 
-	/**
-	 * Returns a shortest path from source to @a t and an empty path if source and @a t are not connected.
-	 *
-	 * @param t Target node.
-	 * @param forward If @c true (default) the path is directed from source to @a t, otherwise the path is reversed.
-	 * @return A shortest path from source to @a t or an empty path.
-	 */
-	virtual std::vector<node> getPath(node t, bool forward=true) const;
+    /**
+     * Returns all shortest paths from source to @a t and an empty set if source
+     * and @a t are not connected.
+     *
+     * @param t Target node.
+     * @param forward If @c true (default) the path is directed from source to
+     * @a t, otherwise the path is reversed.
+     * @return All shortest paths from source node to target node @a t.
+     */
+    virtual std::set<std::vector<node>> getPaths(node t,
+                                                 bool forward = true) const;
 
-	/**
-	 * Returns all shortest paths from source to @a t and an empty set if source and @a t are not connected.
-	 *
-	 * @param t Target node.
-	 * @param forward If @c true (default) the path is directed from source to @a t, otherwise the path is reversed.
-	 * @return All shortest paths from source node to target node @a t.
-	 */
-	virtual std::set<std::vector<node> > getPaths(node t, bool forward=true) const;
+    /* Returns the number of shortest paths to node t.*/
+    bigfloat getNumberOfPaths(node t) const;
 
-	/* Returns the number of shortest paths to node t.*/
-	bigfloat getNumberOfPaths(node t) const;
+    /**
+     * Returns a vector of nodes ordered in increasing distance from the source.
+     *
+     *	For this functionality to be available, storeNodesSortedByDistance has
+     *to be set to true in the constructor. There are no guarantees regarding
+     *the ordering of two nodes with the same distance to the source.
+     *
+     * @param moveOut If set to true, the container will be moved out of the
+     *class instead of copying it; default=true.
+     * @return vector of nodes ordered in increasing distance from the source
+     */
+    virtual std::vector<node> getNodesSortedByDistance(bool moveOut = true);
 
-	/**
-	* Returns a vector of nodes ordered in increasing distance from the source.
-	*
-	*	For this functionality to be available, storeNodesSortedByDistance has to be set to true in the constructor.
-	*	There are no guarantees regarding the ordering of two nodes with the same distance to the source.
-	*
-	* @param moveOut If set to true, the container will be moved out of the class instead of copying it; default=true.
-	* @return vector of nodes ordered in increasing distance from the source
-	*/
-	virtual std::vector<node> getNodesSortedByDistance(bool moveOut=true);
+  protected:
+    const Graph &G;
+    const node source;
+    node target;
+    std::vector<edgeweight> distances;
+    std::vector<std::vector<node>> previous; // predecessors on shortest path
+    std::vector<bigfloat> npaths;
 
-protected:
+    std::vector<node> nodesSortedByDistance;
 
-	const Graph& G;
-	const node source;
-	node target;
-	std::vector<edgeweight> distances;
-	std::vector<std::vector<node> > previous; // predecessors on shortest path
-	std::vector<bigfloat> npaths;
-
-	std::vector<node> nodesSortedByDistance;
-
-	bool storePaths;									//!< if true, paths are reconstructable and the number of paths is stored
-	bool storeNodesSortedByDistance;	//!< if true, store a vector of nodes ordered in increasing distance from the source
+    bool storePaths; //!< if true, paths are reconstructable and the number of
+                     //!< paths is stored
+    bool storeNodesSortedByDistance; //!< if true, store a vector of nodes
+                                     //!< ordered in increasing distance from
+                                     //!< the source
 };
 
-inline edgeweight SSSP::distance(node t) const {
-	return distances[t];
-}
+inline edgeweight SSSP::distance(node t) const { return distances[t]; }
 
 inline bigfloat SSSP::numberOfPaths(node t) const {
-	if (! storePaths) {
-		throw std::runtime_error("number of paths have not been stored");
-	}
-	return npaths[t];
+    if (!storePaths) {
+        throw std::runtime_error("number of paths have not been stored");
+    }
+    return npaths[t];
 }
 
 inline double SSSP::_numberOfPaths(node t) const {
-	if (! storePaths) {
-		throw std::runtime_error("number of paths have not been stored");
-	}
-	bigfloat limit = std::numeric_limits<double>::max();
-	if (npaths[t] > limit) {
-		throw std::overflow_error("number of paths do not fit into a double");
-	}
-	double res;
-	npaths[t].ToDouble(res);
-	return res;
+    if (!storePaths) {
+        throw std::runtime_error("number of paths have not been stored");
+    }
+    bigfloat limit = std::numeric_limits<double>::max();
+    if (npaths[t] > limit) {
+        throw std::overflow_error("number of paths do not fit into a double");
+    }
+    double res;
+    npaths[t].ToDouble(res);
+    return res;
 }
 
 inline std::vector<node> SSSP::getPredecessors(node t) const {
-	if (! storePaths) {
-		throw std::runtime_error("predecessors have not been stored");
-	}
-	return previous[t];
+    if (!storePaths) {
+        throw std::runtime_error("predecessors have not been stored");
+    }
+    return previous[t];
 }
 
-inline bigfloat SSSP::getNumberOfPaths(node t) const {
-	return npaths[t];
-}
+inline bigfloat SSSP::getNumberOfPaths(node t) const { return npaths[t]; }
 
 } /* namespace NetworKit */
 

--- a/include/networkit/viz/PivotMDS.hpp
+++ b/include/networkit/viz/PivotMDS.hpp
@@ -23,40 +23,42 @@ namespace NetworKit {
  * Implementation of PivotMDS proposed by Brandes and Pich.
  */
 class PivotMDS : public GraphLayoutAlgorithm<double> {
-public:
-	/**
-	 * Constructs a PivotMDS object for the given @a graph. The algorithm should embed the graph in @a dim dimensions
-	 * using @a numPivots pivots.
-	 * @param graph
-	 * @param dim
-	 * @param numPivots
-	 */
-	PivotMDS(const Graph& graph, count dim, count numPivots);
+  public:
+    /**
+     * Constructs a PivotMDS object for the given @a graph. The algorithm should
+     * embed the graph in @a dim dimensions using @a numPivots pivots.
+     * @param graph
+     * @param dim
+     * @param numPivots
+     */
+    PivotMDS(const Graph &graph, count dim, count numPivots);
 
-	/*
-	 * Default destructor
-	 */
-	virtual ~PivotMDS() = default;
+    /*
+     * Default destructor
+     */
+    virtual ~PivotMDS() = default;
 
-	/**
-	 * Runs the PivotMDS algorithm.
-	 */
-	void run() override;
+    /**
+     * Runs the PivotMDS algorithm.
+     */
+    void run() override;
 
-private:
-	count dim;
-	count numPivots;
+  private:
+    count dim;
+    count numPivots;
 
-	/**
-	 *  Randomly picks the pivots for the algorithm
-	 */
-	std::vector<node> computePivots();
+    /**
+     *  Randomly picks the pivots for the algorithm
+     */
+    std::vector<node> computePivots();
 
-	/**
-	 * Power method to compute the largest eigenvector and eigenvalue that are stored in @a eigenvector and
-	 * @a eigenvalue.
-	 */
-	void powerMethod(const CSRMatrix& mat, const count n, Vector& eigenvector, double& eigenvalue);
+    /**
+     * Power method to compute the largest eigenvector and eigenvalue that are
+     * stored in @a eigenvector and
+     * @a eigenvalue.
+     */
+    void powerMethod(const CSRMatrix &mat, const count n, Vector &eigenvector,
+                     double &eigenvalue);
 };
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/Closeness.cpp
+++ b/networkit/cpp/centrality/Closeness.cpp
@@ -2,38 +2,31 @@
  * Closeness.cpp
  *
  *  Created on: 03.10.2014
- *      Author: nemes
+ *     Authors: nemes
+ *              Eugenio Angriman <angrimae@hu-berlin.de>
  */
 
-#include <memory>
+#include <omp.h>
 #include <queue>
-#include <stack>
 
-#include "../../include/networkit/auxiliary/Log.hpp"
-#include "../../include/networkit/auxiliary/PrioQueue.hpp"
 #include "../../include/networkit/centrality/Closeness.hpp"
 #include "../../include/networkit/components/ConnectedComponents.hpp"
 #include "../../include/networkit/components/StronglyConnectedComponents.hpp"
-#include "../../include/networkit/distance/BFS.hpp"
-#include "../../include/networkit/distance/Dijkstra.hpp"
-#include "../../include/networkit/distance/SSSP.hpp"
 
 namespace NetworKit {
 
 Closeness::Closeness(const Graph &G, bool normalized,
                      const ClosenessVariant variant)
-    : Centrality(G, normalized), n(G.upperNodeIdBound()), variant(variant) {
+    : Centrality(G, normalized), variant(variant) {
     if (variant == ClosenessVariant::standard) {
         checkConnectedComponents();
     }
 }
 
 Closeness::Closeness(const Graph &G, bool normalized, bool checkConnectedness)
-    : Centrality(G, normalized), n(G.upperNodeIdBound()),
-      variant(ClosenessVariant::standard) {
-    if (checkConnectedness) {
+    : Centrality(G, normalized), variant(ClosenessVariant::standard) {
+    if (checkConnectedness)
         checkConnectedComponents();
-    }
 }
 
 void Closeness::checkConnectedComponents() const {
@@ -56,55 +49,105 @@ void Closeness::checkConnectedComponents() const {
 }
 
 void Closeness::run() {
+    count n = G.upperNodeIdBound();
+
     scoreData.clear();
     scoreData.resize(n);
-    if (variant == ClosenessVariant::generalized) {
-        reachableNodes.assign(n, 0);
-    }
-    edgeweight infDist = std::numeric_limits<edgeweight>::max();
+    visited.clear();
+    visited.resize(omp_get_max_threads(), std::vector<uint8_t>(n));
+    ts.clear();
+    ts.resize(omp_get_max_threads(), 0);
 
-    G.parallelForNodes([&](node s) {
-        std::unique_ptr<SSSP> sssp;
-        if (G.isWeighted()) {
-            sssp.reset(new Dijkstra(G, s, true, true));
-        } else {
-            sssp.reset(new BFS(G, s, true, true));
+    if (G.isWeighted()) {
+        dDist.resize(omp_get_max_threads(), std::vector<double>(n));
+        heaps.reserve(omp_get_max_threads());
+        for (count i = 0; i < omp_get_max_threads(); ++i) {
+            heaps.emplace_back((Compare(dDist[i])));
+            heaps.back().reserve(n);
         }
-        sssp->run();
-
-        std::vector<edgeweight> distances = sssp->getDistances();
-        if (variant == ClosenessVariant::generalized) {
-            reachableNodes[s] =
-                std::count_if(distances.begin(), distances.end(),
-                              [&](edgeweight dist) { return dist != infDist; });
-        }
-
-        double sum = 0;
-        for (auto dist : distances) {
-            if (dist != infDist) {
-                sum += dist;
-            }
-        }
-
-        scoreData[s] = sum == 0 ? 0
-                                : variant == ClosenessVariant::standard
-                                      ? 1.0 / sum
-                                      : (reachableNodes[s] - 1) / sum / (n - 1);
-    });
-    if (normalized) {
-        G.parallelForNodes([&](node s) {
-            scoreData[s] *=
-                (variant == ClosenessVariant::standard ? n
-                                                       : reachableNodes[s]) -
-                1;
-        });
+        dijkstra();
+    } else {
+        uDist.resize(omp_get_max_threads(), std::vector<count>(n));
+        bfs();
     }
 
     hasRun = true;
 }
 
-double Closeness::maximum() {
-    return normalized ? 1.0f : (1.0f / (G.numberOfNodes() - 1));
+void Closeness::bfs() {
+#pragma omp parallel for schedule(dynamic)
+    for (omp_index u = 0; u < static_cast<omp_index>(G.upperNodeIdBound());
+         ++u) {
+        uint8_t &ts_ = ts[omp_get_thread_num()];
+        auto &dist_ = uDist[omp_get_thread_num()];
+        auto &visited_ = visited[omp_get_thread_num()];
+
+        if (ts_++ == 255 && variant != ClosenessVariant::standard) {
+            ts_ = 1;
+            std::fill(visited_.begin(), visited_.end(), 0);
+        }
+
+        std::queue<node> q;
+        q.push(u);
+        dist_[u] = 0;
+        visited_[u] = ts_;
+        double sum = 0.;
+        count reached = 1;
+
+        do {
+            node x = q.front();
+            q.pop();
+            G.forNeighborsOf(x, [&](node y) {
+                if (visited_[y] != ts_) {
+                    visited_[y] = ts_;
+                    dist_[y] = dist_[x] + 1;
+                    sum += dist_[y];
+                    ++reached;
+                    q.push(y);
+                }
+            });
+
+        } while (!q.empty());
+
+        updateScoreData(u, reached, sum);
+    }
 }
 
-} /* namespace NetworKit */
+void Closeness::dijkstra() {
+#pragma omp parallel for schedule(dynamic)
+    for (omp_index u = 0; u < static_cast<omp_index>(G.upperNodeIdBound());
+         ++u) {
+        uint8_t &ts_ = ts[omp_get_thread_num()];
+        auto &dist_ = dDist[omp_get_thread_num()];
+        auto &visited_ = visited[omp_get_thread_num()];
+        auto &heap = heaps[omp_get_thread_num()];
+
+        if (ts_++ == 255 && variant != ClosenessVariant::standard) {
+            ts_ = 1;
+            std::fill(visited_.begin(), visited_.end(), 0);
+        }
+
+        heap.push(u);
+        dist_[u] = 0.;
+        double sum = 0.;
+        count reached = 1;
+
+        do {
+            node x = heap.extract_top();
+            sum += dist_[x];
+            G.forNeighborsOf(x, [&](node y, edgeweight ew) {
+                if (ts_ != visited_[y]) {
+                    ++reached;
+                    visited_[y] = ts_;
+                    dist_[y] = dist_[x] + ew;
+                    heap.push(y);
+                } else if (dist_[y] > dist_[x] + ew) {
+                    dist_[y] = dist_[x] + ew;
+                    heap.update(y);
+                }
+            });
+        } while (!heap.empty());
+        updateScoreData(u, reached, sum);
+    }
+}
+} // namespace NetworKit

--- a/networkit/cpp/centrality/Closeness.cpp
+++ b/networkit/cpp/centrality/Closeness.cpp
@@ -11,98 +11,100 @@
 
 #include "../../include/networkit/auxiliary/Log.hpp"
 #include "../../include/networkit/auxiliary/PrioQueue.hpp"
+#include "../../include/networkit/centrality/Closeness.hpp"
 #include "../../include/networkit/components/ConnectedComponents.hpp"
 #include "../../include/networkit/components/StronglyConnectedComponents.hpp"
 #include "../../include/networkit/distance/BFS.hpp"
 #include "../../include/networkit/distance/Dijkstra.hpp"
 #include "../../include/networkit/distance/SSSP.hpp"
-#include "../../include/networkit/centrality/Closeness.hpp"
 
 namespace NetworKit {
 
 Closeness::Closeness(const Graph &G, bool normalized,
                      const ClosenessVariant variant)
     : Centrality(G, normalized), n(G.upperNodeIdBound()), variant(variant) {
-	if (variant == ClosenessVariant::standard) {
-		checkConnectedComponents();
-	}
+    if (variant == ClosenessVariant::standard) {
+        checkConnectedComponents();
+    }
 }
 
 Closeness::Closeness(const Graph &G, bool normalized, bool checkConnectedness)
     : Centrality(G, normalized), n(G.upperNodeIdBound()),
       variant(ClosenessVariant::standard) {
-	if (checkConnectedness) {
-		checkConnectedComponents();
-	}
+    if (checkConnectedness) {
+        checkConnectedComponents();
+    }
 }
 
 void Closeness::checkConnectedComponents() const {
-	bool multipleComponents = false;
-	if (G.isDirected()) {
-		StronglyConnectedComponents scc(G);
-		scc.run();
-		multipleComponents = scc.numberOfComponents() > 1;
-	} else {
-		ConnectedComponents cc(G);
-		cc.run();
-		multipleComponents = cc.numberOfComponents() > 1;
-	}
-	if (multipleComponents) {
-		throw std::runtime_error(
-		    "Error: the standard definition of closeness is not defined on "
-		    "disconnected graphs. On disconnected graphs, use the generalized "
-		    "definition instead.");
-	}
+    bool multipleComponents = false;
+    if (G.isDirected()) {
+        StronglyConnectedComponents scc(G);
+        scc.run();
+        multipleComponents = scc.numberOfComponents() > 1;
+    } else {
+        ConnectedComponents cc(G);
+        cc.run();
+        multipleComponents = cc.numberOfComponents() > 1;
+    }
+    if (multipleComponents) {
+        throw std::runtime_error(
+            "Error: the standard definition of closeness is not defined on "
+            "disconnected graphs. On disconnected graphs, use the generalized "
+            "definition instead.");
+    }
 }
 
 void Closeness::run() {
-	scoreData.clear();
-	scoreData.resize(n);
-	if (variant == ClosenessVariant::generalized) {
-		reachableNodes.assign(n, 0);
-	}
-	edgeweight infDist = std::numeric_limits<edgeweight>::max();
+    scoreData.clear();
+    scoreData.resize(n);
+    if (variant == ClosenessVariant::generalized) {
+        reachableNodes.assign(n, 0);
+    }
+    edgeweight infDist = std::numeric_limits<edgeweight>::max();
 
-	G.parallelForNodes([&](node s) {
-		std::unique_ptr<SSSP> sssp;
-		if (G.isWeighted()) {
-			sssp.reset(new Dijkstra(G, s, true, true));
-		} else {
-			sssp.reset(new BFS(G, s, true, true));
-		}
-		sssp->run();
+    G.parallelForNodes([&](node s) {
+        std::unique_ptr<SSSP> sssp;
+        if (G.isWeighted()) {
+            sssp.reset(new Dijkstra(G, s, true, true));
+        } else {
+            sssp.reset(new BFS(G, s, true, true));
+        }
+        sssp->run();
 
-		std::vector<edgeweight> distances = sssp->getDistances();
-		if (variant == ClosenessVariant::generalized) {
-			reachableNodes[s] =
-			    std::count_if(distances.begin(), distances.end(),
-			                  [&](edgeweight dist) { return dist != infDist; });
-		}
+        std::vector<edgeweight> distances = sssp->getDistances();
+        if (variant == ClosenessVariant::generalized) {
+            reachableNodes[s] =
+                std::count_if(distances.begin(), distances.end(),
+                              [&](edgeweight dist) { return dist != infDist; });
+        }
 
-		double sum = 0;
-		for (auto dist : distances) {
-			if (dist != infDist) {
-				sum += dist;
-			}
-		}
+        double sum = 0;
+        for (auto dist : distances) {
+            if (dist != infDist) {
+                sum += dist;
+            }
+        }
 
-		scoreData[s] = sum == 0 ? 0
-		                        : variant == ClosenessVariant::standard
-		                              ? 1.0 / sum
-		                              : (reachableNodes[s] - 1) / sum / (n - 1);
-	});
-	if (normalized) {
-		G.parallelForNodes([&](node s) {
-			scoreData[s] *=
-			    (variant == ClosenessVariant::standard ? n : reachableNodes[s]) - 1;
-		});
-	}
+        scoreData[s] = sum == 0 ? 0
+                                : variant == ClosenessVariant::standard
+                                      ? 1.0 / sum
+                                      : (reachableNodes[s] - 1) / sum / (n - 1);
+    });
+    if (normalized) {
+        G.parallelForNodes([&](node s) {
+            scoreData[s] *=
+                (variant == ClosenessVariant::standard ? n
+                                                       : reachableNodes[s]) -
+                1;
+        });
+    }
 
-	hasRun = true;
+    hasRun = true;
 }
 
 double Closeness::maximum() {
-	return normalized ? 1.0f : (1.0f / (G.numberOfNodes() - 1));
+    return normalized ? 1.0f : (1.0f / (G.numberOfNodes() - 1));
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -12,12 +12,6 @@
 
 #include "../../../include/networkit/auxiliary/Log.hpp"
 #include "../../../include/networkit/auxiliary/Timer.hpp"
-#include "../../../include/networkit/generators/DorogovtsevMendesGenerator.hpp"
-#include "../../../include/networkit/generators/ErdosRenyiGenerator.hpp"
-#include "../../../include/networkit/io/METISGraphReader.hpp"
-#include "../../../include/networkit/io/SNAPGraphReader.hpp"
-#include "../../../include/networkit/structures/Cover.hpp"
-#include "../../../include/networkit/structures/Partition.hpp"
 #include "../../../include/networkit/centrality/ApproxBetweenness.hpp"
 #include "../../../include/networkit/centrality/ApproxCloseness.hpp"
 #include "../../../include/networkit/centrality/ApproxGroupBetweenness.hpp"
@@ -42,1431 +36,1476 @@
 #include "../../../include/networkit/centrality/SpanningEdgeCentrality.hpp"
 #include "../../../include/networkit/centrality/TopCloseness.hpp"
 #include "../../../include/networkit/centrality/TopHarmonicCloseness.hpp"
+#include "../../../include/networkit/generators/DorogovtsevMendesGenerator.hpp"
+#include "../../../include/networkit/generators/ErdosRenyiGenerator.hpp"
+#include "../../../include/networkit/io/METISGraphReader.hpp"
+#include "../../../include/networkit/io/SNAPGraphReader.hpp"
+#include "../../../include/networkit/structures/Cover.hpp"
+#include "../../../include/networkit/structures/Partition.hpp"
 
 namespace NetworKit {
 
 class CentralityGTest : public testing::Test {};
 
 TEST_F(CentralityGTest, testBetweennessCentrality) {
-	/* Graph:
-	 0    3
-	  \  / \
-	   2    5
-	  /  \ /
-	 1    4
-	*/
-	count n = 6;
-	Graph G(n);
+    /* Graph:
+     0    3
+      \  / \
+       2    5
+      /  \ /
+     1    4
+    */
+    count n = 6;
+    Graph G(n);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
 
-	Betweenness centrality(G);
-	centrality.run();
-	std::vector<double> bc = centrality.scores();
+    Betweenness centrality(G);
+    centrality.run();
+    std::vector<double> bc = centrality.scores();
 
-	const double tol = 1e-3;
-	EXPECT_NEAR(0.0, bc[0], tol);
-	EXPECT_NEAR(0.0, bc[1], tol);
-	EXPECT_NEAR(15.0, bc[2], tol);
-	EXPECT_NEAR(3.0, bc[3], tol);
-	EXPECT_NEAR(3.0, bc[4], tol);
-	EXPECT_NEAR(1.0, bc[5], tol);
+    const double tol = 1e-3;
+    EXPECT_NEAR(0.0, bc[0], tol);
+    EXPECT_NEAR(0.0, bc[1], tol);
+    EXPECT_NEAR(15.0, bc[2], tol);
+    EXPECT_NEAR(3.0, bc[3], tol);
+    EXPECT_NEAR(3.0, bc[4], tol);
+    EXPECT_NEAR(1.0, bc[5], tol);
 }
 
 TEST_F(CentralityGTest, testBetweenness2Centrality) {
-	/* Graph:
-	      0    3
-	      \  / \
-	      2    5
-	      /  \ /
-	      1    4
-	*/
-	count n = 6;
-	Graph G(n);
+    /* Graph:
+          0    3
+          \  / \
+          2    5
+          /  \ /
+          1    4
+    */
+    count n = 6;
+    Graph G(n);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
 
-	Betweenness centrality(G);
-	centrality.run();
-	std::vector<double> bc = centrality.scores();
+    Betweenness centrality(G);
+    centrality.run();
+    std::vector<double> bc = centrality.scores();
 
-	const double tol = 1e-3;
-	EXPECT_NEAR(0.0, bc[0], tol);
-	EXPECT_NEAR(0.0, bc[1], tol);
-	EXPECT_NEAR(15.0, bc[2], tol);
-	EXPECT_NEAR(3.0, bc[3], tol);
-	EXPECT_NEAR(3.0, bc[4], tol);
-	EXPECT_NEAR(1.0, bc[5], tol);
+    const double tol = 1e-3;
+    EXPECT_NEAR(0.0, bc[0], tol);
+    EXPECT_NEAR(0.0, bc[1], tol);
+    EXPECT_NEAR(15.0, bc[2], tol);
+    EXPECT_NEAR(3.0, bc[3], tol);
+    EXPECT_NEAR(3.0, bc[4], tol);
+    EXPECT_NEAR(1.0, bc[5], tol);
 }
 
 TEST_F(CentralityGTest, runApproxBetweennessSmallGraph) {
-	/* Graph:
-	 0    3
-	  \  / \
-	   2   5
-	  / \ /
-	 1   4
-	*/
-	count n = 6;
-	Graph G(n);
+    /* Graph:
+     0    3
+      \  / \
+       2   5
+      / \ /
+     1   4
+    */
+    count n = 6;
+    Graph G(n);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
 
-	double epsilon = 0.1; // error
-	double delta = 0.1;   // confidence
-	ApproxBetweenness centrality(G, epsilon, delta);
-	centrality.run();
-	std::vector<double> bc = centrality.scores();
+    double epsilon = 0.1; // error
+    double delta = 0.1;   // confidence
+    ApproxBetweenness centrality(G, epsilon, delta);
+    centrality.run();
+    std::vector<double> bc = centrality.scores();
 
-	ASSERT_LE(centrality.scores().size(), 1.0 / (epsilon * epsilon));
+    ASSERT_LE(centrality.scores().size(), 1.0 / (epsilon * epsilon));
 
-	DEBUG("scores: ", bc);
+    DEBUG("scores: ", bc);
 }
 
 TEST_F(CentralityGTest, testBetweennessCentralityWeighted) {
-	/* Graph:
-	 0    3   6
-	  \  / \ /
-	   2 -- 5
-	  /  \ / \
-	 1    4   7
+    /* Graph:
+     0    3   6
+      \  / \ /
+       2 -- 5
+      /  \ / \
+     1    4   7
 
-	 Edges in the upper row have weight 3,
-	 the edge in the middle row has weight 1.5,
-	 edges in the lower row have weight 2.
-	*/
-	count n = 8;
-	Graph G(n, true);
+     Edges in the upper row have weight 3,
+     the edge in the middle row has weight 1.5,
+     edges in the lower row have weight 2.
+    */
+    count n = 8;
+    Graph G(n, true);
 
-	G.addEdge(0, 2, 3);
-	G.addEdge(1, 2, 2);
-	G.addEdge(2, 3, 3);
-	G.addEdge(2, 4, 2);
-	G.addEdge(2, 5, 1.5);
-	G.addEdge(3, 5, 3);
-	G.addEdge(4, 5, 2);
-	G.addEdge(5, 6, 3);
-	G.addEdge(5, 7, 2);
+    G.addEdge(0, 2, 3);
+    G.addEdge(1, 2, 2);
+    G.addEdge(2, 3, 3);
+    G.addEdge(2, 4, 2);
+    G.addEdge(2, 5, 1.5);
+    G.addEdge(3, 5, 3);
+    G.addEdge(4, 5, 2);
+    G.addEdge(5, 6, 3);
+    G.addEdge(5, 7, 2);
 
-	Betweenness centrality(G);
-	centrality.run();
-	std::vector<double> bc = centrality.scores();
+    Betweenness centrality(G);
+    centrality.run();
+    std::vector<double> bc = centrality.scores();
 
-	const double tol = 1e-3;
-	EXPECT_NEAR(0.0, bc[0], tol);
-	EXPECT_NEAR(0.0, bc[1], tol);
-	EXPECT_NEAR(23.0, bc[2], tol);
-	EXPECT_NEAR(0.0, bc[3], tol);
-	EXPECT_NEAR(0.0, bc[4], tol);
-	EXPECT_NEAR(23.0, bc[5], tol);
-	EXPECT_NEAR(0.0, bc[6], tol);
-	EXPECT_NEAR(0.0, bc[7], tol);
+    const double tol = 1e-3;
+    EXPECT_NEAR(0.0, bc[0], tol);
+    EXPECT_NEAR(0.0, bc[1], tol);
+    EXPECT_NEAR(23.0, bc[2], tol);
+    EXPECT_NEAR(0.0, bc[3], tol);
+    EXPECT_NEAR(0.0, bc[4], tol);
+    EXPECT_NEAR(23.0, bc[5], tol);
+    EXPECT_NEAR(0.0, bc[6], tol);
+    EXPECT_NEAR(0.0, bc[7], tol);
 }
 
 // TODO: replace by smaller graph
 TEST_F(CentralityGTest, testKatzCentralityDirected) {
-	SNAPGraphReader reader;
-	Graph G = reader.read("input/wiki-Vote.txt");
-	KatzCentrality kc(G);
+    SNAPGraphReader reader;
+    Graph G = reader.read("input/wiki-Vote.txt");
+    KatzCentrality kc(G);
 
-	DEBUG("start kc run");
-	kc.run();
-	DEBUG("finish kc");
-	std::vector<std::pair<node, double>> kc_ranking = kc.ranking();
-	// std::vector<double> kc_scores = kc.scores();
+    DEBUG("start kc run");
+    kc.run();
+    DEBUG("finish kc");
+    std::vector<std::pair<node, double>> kc_ranking = kc.ranking();
+    // std::vector<double> kc_scores = kc.scores();
 
-	EXPECT_EQ(kc_ranking[0].first, 699);
+    EXPECT_EQ(kc_ranking[0].first, 699);
 }
 
 TEST_F(CentralityGTest, testKatzTopk) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/caidaRouterLevel.graph");
+    METISGraphReader reader;
+    Graph G = reader.read("input/caidaRouterLevel.graph");
 
-	// Compute max. degree to ensure that we use the same alpha for both algos.
-	count maxDegree = 0;
-	G.forNodes([&](node u) {
-		if (G.degree(u) > maxDegree)
-			maxDegree = G.degree(u);
-	});
+    // Compute max. degree to ensure that we use the same alpha for both algos.
+    count maxDegree = 0;
+    G.forNodes([&](node u) {
+        if (G.degree(u) > maxDegree)
+            maxDegree = G.degree(u);
+    });
 
-	KatzCentrality exactAlgo(G, 1.0 / (maxDegree + 1), 1.0);
-	DynKatzCentrality topAlgo(G, 100);
-	exactAlgo.run();
-	topAlgo.run();
+    KatzCentrality exactAlgo(G, 1.0 / (maxDegree + 1), 1.0);
+    DynKatzCentrality topAlgo(G, 100);
+    exactAlgo.run();
+    topAlgo.run();
 
-	// We cannot compare the ranking as the algorithms might return different
-	// rankings for nodes that have equal/nearly equal scores. Instead,
-	// epsilon-compare the exact scores of the i-th node and the expected i-th
-	// node.
-	auto exactRanking = exactAlgo.ranking();
-	auto topRanking = topAlgo.ranking();
-	for (count i = 0; i < std::min(G.numberOfNodes(), count{100}); i++)
-		EXPECT_NEAR(exactAlgo.score(topRanking[i].first), exactRanking[i].second,
-		            1e-6);
+    // We cannot compare the ranking as the algorithms might return different
+    // rankings for nodes that have equal/nearly equal scores. Instead,
+    // epsilon-compare the exact scores of the i-th node and the expected i-th
+    // node.
+    auto exactRanking = exactAlgo.ranking();
+    auto topRanking = topAlgo.ranking();
+    for (count i = 0; i < std::min(G.numberOfNodes(), count{100}); i++)
+        EXPECT_NEAR(exactAlgo.score(topRanking[i].first),
+                    exactRanking[i].second, 1e-6);
 }
 
 TEST_F(CentralityGTest, testKatzDynamicAddition) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/caidaRouterLevel.graph");
-	DynKatzCentrality kc(G, 100);
-	DEBUG("start kc run");
-	kc.run();
-	DEBUG("finish kc");
-	node u, v;
-	do {
-		u = G.randomNode();
-		v = G.randomNode();
-	} while (G.hasEdge(u, v));
-	GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
-	kc.update(e);
-	G.addEdge(u, v);
-	DynKatzCentrality kc2(G, 100);
-	kc2.run();
-	const edgeweight tol = 1e-9;
-	for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
-		INFO("i = ", i);
-		G.forNodes([&](node u) {
-			// if (kc.nPaths[i][u] != kc2.nPaths[i][u]) {
-			//	 INFO("i = ", i, ", node ", u, ", dyn kc paths: ", kc.nPaths[i][u], ",
-			// stat paths: ", kc2.nPaths[i][u]);
-			// }
-			EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u]);
-		});
-	}
-	G.forNodes([&](node u) {
-		EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
-		EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
-	});
+    METISGraphReader reader;
+    Graph G = reader.read("input/caidaRouterLevel.graph");
+    DynKatzCentrality kc(G, 100);
+    DEBUG("start kc run");
+    kc.run();
+    DEBUG("finish kc");
+    node u, v;
+    do {
+        u = G.randomNode();
+        v = G.randomNode();
+    } while (G.hasEdge(u, v));
+    GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
+    kc.update(e);
+    G.addEdge(u, v);
+    DynKatzCentrality kc2(G, 100);
+    kc2.run();
+    const edgeweight tol = 1e-9;
+    for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
+        INFO("i = ", i);
+        G.forNodes([&](node u) {
+            // if (kc.nPaths[i][u] != kc2.nPaths[i][u]) {
+            //	 INFO("i = ", i, ", node ", u, ", dyn kc paths: ",
+            // kc.nPaths[i][u], ",
+            // stat paths: ", kc2.nPaths[i][u]);
+            // }
+            EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u]);
+        });
+    }
+    G.forNodes([&](node u) {
+        EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
+        EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
+    });
 
-	INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
+    INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
 }
 
 TEST_F(CentralityGTest, testKatzDynamicDeletion) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/caidaRouterLevel.graph");
-	DynKatzCentrality kc(G, 100);
-	DEBUG("start kc run");
-	kc.run();
-	DEBUG("finish kc");
-	std::pair<node, node> p = G.randomEdge();
-	node u = p.first;
-	node v = p.second;
-	INFO("Deleting edge ", u, ", ", v);
-	GraphEvent e(GraphEvent::EDGE_REMOVAL, u, v, 1.0);
-	G.removeEdge(u, v);
-	kc.update(e);
-	DynKatzCentrality kc2(G, 100);
-	kc2.run();
-	const edgeweight tol = 1e-9;
-	for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
-		INFO("i = ", i);
-		G.forNodes([&](node u) {
-			if (kc.nPaths[i][u] != kc2.nPaths[i][u]) {
-				INFO("i = ", i, ", node ", u, ", dyn kc paths: ", kc.nPaths[i][u],
-				     ", stat paths: ", kc2.nPaths[i][u]);
-			}
-			EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u]);
-		});
-	}
-	G.forNodes([&](node u) {
-		EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
-		EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
-	});
+    METISGraphReader reader;
+    Graph G = reader.read("input/caidaRouterLevel.graph");
+    DynKatzCentrality kc(G, 100);
+    DEBUG("start kc run");
+    kc.run();
+    DEBUG("finish kc");
+    std::pair<node, node> p = G.randomEdge();
+    node u = p.first;
+    node v = p.second;
+    INFO("Deleting edge ", u, ", ", v);
+    GraphEvent e(GraphEvent::EDGE_REMOVAL, u, v, 1.0);
+    G.removeEdge(u, v);
+    kc.update(e);
+    DynKatzCentrality kc2(G, 100);
+    kc2.run();
+    const edgeweight tol = 1e-9;
+    for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
+        INFO("i = ", i);
+        G.forNodes([&](node u) {
+            if (kc.nPaths[i][u] != kc2.nPaths[i][u]) {
+                INFO("i = ", i, ", node ", u,
+                     ", dyn kc paths: ", kc.nPaths[i][u],
+                     ", stat paths: ", kc2.nPaths[i][u]);
+            }
+            EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u]);
+        });
+    }
+    G.forNodes([&](node u) {
+        EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
+        EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
+    });
 
-	INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
+    INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
 }
 
 TEST_F(CentralityGTest, testKatzDynamicBuilding) {
-	METISGraphReader reader;
-	Graph GIn = reader.read("input/hep-th.graph");
+    METISGraphReader reader;
+    Graph GIn = reader.read("input/hep-th.graph");
 
-	// Find a single max-degree node and add its edges to G.
-	// (This guarantees that alpha is correct.)
-	node maxNode = 0;
-	GIn.forNodes([&](node u) {
-		if (GIn.degree(u) > GIn.degree(maxNode))
-			maxNode = u;
-	});
+    // Find a single max-degree node and add its edges to G.
+    // (This guarantees that alpha is correct.)
+    node maxNode = 0;
+    GIn.forNodes([&](node u) {
+        if (GIn.degree(u) > GIn.degree(maxNode))
+            maxNode = u;
+    });
 
-	Graph G(GIn.upperNodeIdBound());
+    Graph G(GIn.upperNodeIdBound());
 
-	GIn.forEdgesOf(maxNode, [&](node u, edgeweight) { G.addEdge(maxNode, u); });
+    GIn.forEdgesOf(maxNode, [&](node u, edgeweight) { G.addEdge(maxNode, u); });
 
-	// Now run the algo. and add other some edges to check the correctness of the
-	// dynamic part.
-	DynKatzCentrality dynAlgo(G, 100);
-	dynAlgo.run();
+    // Now run the algo. and add other some edges to check the correctness of
+    // the dynamic part.
+    DynKatzCentrality dynAlgo(G, 100);
+    dynAlgo.run();
 
-	count edgesProcessed = 0;
-	GIn.forEdges([&](node u, node v) {
-		if (u == maxNode || v == maxNode)
-			return;
-		if (edgesProcessed > 1000)
-			return;
-		GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
-		dynAlgo.update(e);
-		G.addEdge(u, v);
-		edgesProcessed++;
-	});
+    count edgesProcessed = 0;
+    GIn.forEdges([&](node u, node v) {
+        if (u == maxNode || v == maxNode)
+            return;
+        if (edgesProcessed > 1000)
+            return;
+        GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
+        dynAlgo.update(e);
+        G.addEdge(u, v);
+        edgesProcessed++;
+    });
 
-	DynKatzCentrality topAlgo(G, 100);
-	topAlgo.run();
+    DynKatzCentrality topAlgo(G, 100);
+    topAlgo.run();
 
-	auto topRanking = topAlgo.ranking();
-	auto dynRanking = dynAlgo.ranking();
-	for (count i = 0; i < std::min(G.numberOfNodes(), count{100}); i++)
-		EXPECT_FALSE(
-		    dynAlgo.areDistinguished(topRanking[i].first, dynRanking[i].first))
-		    << "Nodes " << topRanking[i].first << " and " << dynRanking[i].first
-		    << " should not be distinguished!";
+    auto topRanking = topAlgo.ranking();
+    auto dynRanking = dynAlgo.ranking();
+    for (count i = 0; i < std::min(G.numberOfNodes(), count{100}); i++)
+        EXPECT_FALSE(
+            dynAlgo.areDistinguished(topRanking[i].first, dynRanking[i].first))
+            << "Nodes " << topRanking[i].first << " and " << dynRanking[i].first
+            << " should not be distinguished!";
 }
 
 TEST_F(CentralityGTest, testKatzDirectedAddition) {
-	// Same graph as in testCoreDecompositionDirected.
-	count n = 16;
-	Graph G(n, false, true);
+    // Same graph as in testCoreDecompositionDirected.
+    count n = 16;
+    Graph G(n, false, true);
 
-	G.addEdge(2, 4);
-	G.addEdge(3, 4);
-	G.addEdge(4, 5);
-	G.addEdge(5, 7);
-	G.addEdge(6, 7);
+    G.addEdge(2, 4);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(5, 7);
+    G.addEdge(6, 7);
 
-	G.addEdge(6, 8);
-	G.addEdge(6, 9);
-	G.addEdge(6, 11);
-	G.addEdge(7, 12);
-	G.addEdge(8, 9);
+    G.addEdge(6, 8);
+    G.addEdge(6, 9);
+    G.addEdge(6, 11);
+    G.addEdge(7, 12);
+    G.addEdge(8, 9);
 
-	G.addEdge(8, 10);
-	G.addEdge(8, 11);
-	G.addEdge(8, 13);
-	G.addEdge(9, 10);
-	G.addEdge(9, 11);
+    G.addEdge(8, 10);
+    G.addEdge(8, 11);
+    G.addEdge(8, 13);
+    G.addEdge(9, 10);
+    G.addEdge(9, 11);
 
-	G.addEdge(9, 13);
-	G.addEdge(10, 11);
-	G.addEdge(10, 13);
-	G.addEdge(10, 14);
-	G.addEdge(11, 13);
+    G.addEdge(9, 13);
+    G.addEdge(10, 11);
+    G.addEdge(10, 13);
+    G.addEdge(10, 14);
+    G.addEdge(11, 13);
 
-	G.addEdge(11, 14);
-	G.addEdge(12, 15);
-	G.addEdge(13, 14);
-	G.addEdge(14, 15);
+    G.addEdge(11, 14);
+    G.addEdge(12, 15);
+    G.addEdge(13, 14);
+    G.addEdge(14, 15);
 
-	DynKatzCentrality kc(G, 5);
-	kc.run();
+    DynKatzCentrality kc(G, 5);
+    kc.run();
 
-	node u, v;
-	Aux::Random::setSeed(42, false);
-	do {
-		u = G.randomNode();
-		v = G.randomNode();
-	} while (G.hasEdge(u, v));
-	GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
-	kc.update(e);
-	G.addEdge(u, v);
+    node u, v;
+    Aux::Random::setSeed(42, false);
+    do {
+        u = G.randomNode();
+        v = G.randomNode();
+    } while (G.hasEdge(u, v));
+    GraphEvent e(GraphEvent::EDGE_ADDITION, u, v, 1.0);
+    kc.update(e);
+    G.addEdge(u, v);
 
-	DynKatzCentrality kc2(G, 5);
-	kc2.run();
+    DynKatzCentrality kc2(G, 5);
+    kc2.run();
 
-	for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
-		G.forNodes([&](node u) { EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u]); });
-	}
-	const edgeweight tol = 1e-9;
-	G.forNodes([&](node u) {
-		EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
-		EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
-	});
+    for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
+        G.forNodes(
+            [&](node u) { EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u]); });
+    }
+    const edgeweight tol = 1e-9;
+    G.forNodes([&](node u) {
+        EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
+        EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
+    });
 
-	INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
+    INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
 }
 
 TEST_F(CentralityGTest, testKatzDirectedDeletion) {
-	// Same graph as in testCoreDecompositionDirected.
-	count n = 16;
-	Graph G(n, false, true);
+    // Same graph as in testCoreDecompositionDirected.
+    count n = 16;
+    Graph G(n, false, true);
 
-	G.addEdge(2, 4);
-	G.addEdge(3, 4);
-	G.addEdge(4, 5);
-	G.addEdge(5, 7);
-	G.addEdge(6, 7);
+    G.addEdge(2, 4);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(5, 7);
+    G.addEdge(6, 7);
 
-	G.addEdge(6, 8);
-	G.addEdge(6, 9);
-	G.addEdge(6, 11);
-	G.addEdge(7, 12);
-	G.addEdge(8, 9);
+    G.addEdge(6, 8);
+    G.addEdge(6, 9);
+    G.addEdge(6, 11);
+    G.addEdge(7, 12);
+    G.addEdge(8, 9);
 
-	G.addEdge(8, 10);
-	G.addEdge(8, 11);
-	G.addEdge(8, 13);
-	G.addEdge(9, 10);
-	G.addEdge(9, 11);
+    G.addEdge(8, 10);
+    G.addEdge(8, 11);
+    G.addEdge(8, 13);
+    G.addEdge(9, 10);
+    G.addEdge(9, 11);
 
-	G.addEdge(9, 13);
-	G.addEdge(10, 11);
-	G.addEdge(10, 13);
-	G.addEdge(10, 14);
-	G.addEdge(11, 13);
+    G.addEdge(9, 13);
+    G.addEdge(10, 11);
+    G.addEdge(10, 13);
+    G.addEdge(10, 14);
+    G.addEdge(11, 13);
 
-	G.addEdge(11, 14);
-	G.addEdge(12, 15);
-	G.addEdge(13, 14);
-	G.addEdge(14, 15);
+    G.addEdge(11, 14);
+    G.addEdge(12, 15);
+    G.addEdge(13, 14);
+    G.addEdge(14, 15);
 
-	DynKatzCentrality kc(G, 5);
-	kc.run();
+    DynKatzCentrality kc(G, 5);
+    kc.run();
 
-	Aux::Random::setSeed(42, false);
-	std::pair<node, node> p = G.randomEdge();
-	node u = p.first;
-	node v = p.second;
-	INFO("Removing ", u, " -> ", v);
-	GraphEvent e(GraphEvent::EDGE_REMOVAL, u, v, 1.0);
-	G.removeEdge(u, v);
-	kc.update(e);
+    Aux::Random::setSeed(42, false);
+    std::pair<node, node> p = G.randomEdge();
+    node u = p.first;
+    node v = p.second;
+    INFO("Removing ", u, " -> ", v);
+    GraphEvent e(GraphEvent::EDGE_REMOVAL, u, v, 1.0);
+    G.removeEdge(u, v);
+    kc.update(e);
 
-	DynKatzCentrality kc2(G, 5);
-	kc2.run();
+    DynKatzCentrality kc2(G, 5);
+    kc2.run();
 
-	for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
-		G.forNodes([&](node u) {
-			EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u])
-			    << i << "-length paths ending in " << u << " do not match!";
-		});
-	}
-	const edgeweight tol = 1e-9;
-	G.forNodes([&](node u) {
-		EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
-		EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
-	});
+    for (count i = 0; i <= std::min(kc.levelReached, kc2.levelReached); i++) {
+        G.forNodes([&](node u) {
+            EXPECT_EQ(kc.nPaths[i][u], kc2.nPaths[i][u])
+                << i << "-length paths ending in " << u << " do not match!";
+        });
+    }
+    const edgeweight tol = 1e-9;
+    G.forNodes([&](node u) {
+        EXPECT_NEAR(kc.score(u), kc2.score(u), tol);
+        EXPECT_NEAR(kc.bound(u), kc2.bound(u), tol);
+    });
 
-	INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
+    INFO("Level reached: ", kc.levelReached, ", ", kc2.levelReached);
 }
 
 // TODO: replace by smaller graph
 TEST_F(CentralityGTest, testPageRankDirected) {
-	SNAPGraphReader reader;
-	Graph G = reader.read("input/wiki-Vote.txt");
-	PageRank pr(G);
+    SNAPGraphReader reader;
+    Graph G = reader.read("input/wiki-Vote.txt");
+    PageRank pr(G);
 
-	DEBUG("start pr run");
-	pr.run();
-	DEBUG("finish pr");
-	std::vector<std::pair<node, double>> pr_ranking = pr.ranking();
+    DEBUG("start pr run");
+    pr.run();
+    DEBUG("finish pr");
+    std::vector<std::pair<node, double>> pr_ranking = pr.ranking();
 
-	const double tol = 1e-3;
-	EXPECT_EQ(pr_ranking[0].first, 699);
-	EXPECT_NEAR(pr_ranking[0].second, 0.00432, tol);
+    const double tol = 1e-3;
+    EXPECT_EQ(pr_ranking[0].first, 699);
+    EXPECT_NEAR(pr_ranking[0].second, 0.00432, tol);
 }
 
 TEST_F(CentralityGTest, testEigenvectorCentrality) {
-	/* Graph:
-	 0    3   6
-	  \  / \ /
-	   2 -- 5
-	  /  \ / \
-	 1    4   7
+    /* Graph:
+     0    3   6
+      \  / \ /
+       2 -- 5
+      /  \ / \
+     1    4   7
 
-	 Edges in the upper row have weight 3,
-	 the edge in the middle row has weight 1.5,
-	 edges in the lower row have weight 2.
-	*/
-	count n = 8;
-	Graph G(n, true);
+     Edges in the upper row have weight 3,
+     the edge in the middle row has weight 1.5,
+     edges in the lower row have weight 2.
+    */
+    count n = 8;
+    Graph G(n, true);
 
-	G.addEdge(0, 2, 3);
-	G.addEdge(1, 2, 2);
-	G.addEdge(2, 3, 3);
-	G.addEdge(2, 4, 2);
-	G.addEdge(2, 5, 1.5);
-	G.addEdge(3, 5, 3);
-	G.addEdge(4, 5, 2);
-	G.addEdge(5, 6, 3);
-	G.addEdge(5, 7, 2);
+    G.addEdge(0, 2, 3);
+    G.addEdge(1, 2, 2);
+    G.addEdge(2, 3, 3);
+    G.addEdge(2, 4, 2);
+    G.addEdge(2, 5, 1.5);
+    G.addEdge(3, 5, 3);
+    G.addEdge(4, 5, 2);
+    G.addEdge(5, 6, 3);
+    G.addEdge(5, 7, 2);
 
-	EigenvectorCentrality centrality(G);
-	centrality.run();
-	std::vector<double> cen = centrality.scores();
+    EigenvectorCentrality centrality(G);
+    centrality.run();
+    std::vector<double> cen = centrality.scores();
 
-	// computed with Matlab
-	const double tol = 1e-4;
-	EXPECT_NEAR(0.2254, fabs(cen[0]), tol);
-	EXPECT_NEAR(0.1503, fabs(cen[1]), tol);
-	EXPECT_NEAR(0.5290, fabs(cen[2]), tol);
-	EXPECT_NEAR(0.4508, fabs(cen[3]), tol);
-	EXPECT_NEAR(0.3006, fabs(cen[4]), tol);
-	EXPECT_NEAR(0.5290, fabs(cen[5]), tol);
-	EXPECT_NEAR(0.2254, fabs(cen[6]), tol);
-	EXPECT_NEAR(0.1503, fabs(cen[7]), tol);
+    // computed with Matlab
+    const double tol = 1e-4;
+    EXPECT_NEAR(0.2254, fabs(cen[0]), tol);
+    EXPECT_NEAR(0.1503, fabs(cen[1]), tol);
+    EXPECT_NEAR(0.5290, fabs(cen[2]), tol);
+    EXPECT_NEAR(0.4508, fabs(cen[3]), tol);
+    EXPECT_NEAR(0.3006, fabs(cen[4]), tol);
+    EXPECT_NEAR(0.5290, fabs(cen[5]), tol);
+    EXPECT_NEAR(0.2254, fabs(cen[6]), tol);
+    EXPECT_NEAR(0.1503, fabs(cen[7]), tol);
 }
 
 TEST_F(CentralityGTest, testPageRankCentrality) {
-	/* Graph:
-	 0    3   6
-	  \  / \ /
-	   2 -- 5
-	  /  \ / \
-	 1    4   7
+    /* Graph:
+     0    3   6
+      \  / \ /
+       2 -- 5
+      /  \ / \
+     1    4   7
 
-	 Edges in the upper row have weight 3,
-	 the edge in the middle row has weight 1.5,
-	 edges in the lower row have weight 2.
-	*/
-	count n = 8;
-	Graph G(n, true);
+     Edges in the upper row have weight 3,
+     the edge in the middle row has weight 1.5,
+     edges in the lower row have weight 2.
+    */
+    count n = 8;
+    Graph G(n, true);
 
-	G.addEdge(0, 2, 3);
-	G.addEdge(1, 2, 2);
-	G.addEdge(2, 3, 3);
-	G.addEdge(2, 4, 2);
-	G.addEdge(2, 5, 1.5);
-	G.addEdge(3, 5, 3);
-	G.addEdge(4, 5, 2);
-	G.addEdge(5, 6, 3);
-	G.addEdge(5, 7, 2);
+    G.addEdge(0, 2, 3);
+    G.addEdge(1, 2, 2);
+    G.addEdge(2, 3, 3);
+    G.addEdge(2, 4, 2);
+    G.addEdge(2, 5, 1.5);
+    G.addEdge(3, 5, 3);
+    G.addEdge(4, 5, 2);
+    G.addEdge(5, 6, 3);
+    G.addEdge(5, 7, 2);
 
-	double damp = 0.85;
-	PageRank centrality(G, damp);
-	centrality.run();
-	std::vector<double> cen = centrality.scores();
+    double damp = 0.85;
+    PageRank centrality(G, damp);
+    centrality.run();
+    std::vector<double> cen = centrality.scores();
 
-	// compare to Matlab results
-	const double tol = 1e-4;
-	EXPECT_NEAR(0.0753, fabs(cen[0]), tol);
-	EXPECT_NEAR(0.0565, fabs(cen[1]), tol);
-	EXPECT_NEAR(0.2552, fabs(cen[2]), tol);
-	EXPECT_NEAR(0.1319, fabs(cen[3]), tol);
-	EXPECT_NEAR(0.0942, fabs(cen[4]), tol);
-	EXPECT_NEAR(0.2552, fabs(cen[5]), tol);
-	EXPECT_NEAR(0.0753, fabs(cen[6]), tol);
-	EXPECT_NEAR(0.0565, fabs(cen[7]), tol);
+    // compare to Matlab results
+    const double tol = 1e-4;
+    EXPECT_NEAR(0.0753, fabs(cen[0]), tol);
+    EXPECT_NEAR(0.0565, fabs(cen[1]), tol);
+    EXPECT_NEAR(0.2552, fabs(cen[2]), tol);
+    EXPECT_NEAR(0.1319, fabs(cen[3]), tol);
+    EXPECT_NEAR(0.0942, fabs(cen[4]), tol);
+    EXPECT_NEAR(0.2552, fabs(cen[5]), tol);
+    EXPECT_NEAR(0.0753, fabs(cen[6]), tol);
+    EXPECT_NEAR(0.0565, fabs(cen[7]), tol);
 }
 
 TEST_F(CentralityGTest, benchSequentialBetweennessCentralityOnRealGraph) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/celegans_metabolic.graph");
-	Betweenness bc(G);
-	bc.run();
-	std::vector<std::pair<node, double>> ranking = bc.ranking();
-	INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
+    Betweenness bc(G);
+    bc.run();
+    std::vector<std::pair<node, double>> ranking = bc.ranking();
+    INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
 }
 
 TEST_F(CentralityGTest, benchParallelBetweennessCentralityOnRealGraph) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/celegans_metabolic.graph");
-	Betweenness bc(G);
-	bc.run();
-	std::vector<std::pair<node, double>> ranking = bc.ranking();
-	INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
+    Betweenness bc(G);
+    bc.run();
+    std::vector<std::pair<node, double>> ranking = bc.ranking();
+    INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
 }
 
 TEST_F(CentralityGTest, benchEigenvectorCentralityOnRealGraph) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/celegans_metabolic.graph");
-	EigenvectorCentrality cen(G);
-	cen.run();
-	std::vector<std::pair<node, double>> ranking = cen.ranking();
-	INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
+    EigenvectorCentrality cen(G);
+    cen.run();
+    std::vector<std::pair<node, double>> ranking = cen.ranking();
+    INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
 }
 
 TEST_F(CentralityGTest, benchPageRankCentralityOnRealGraph) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/celegans_metabolic.graph");
-	double damp = 0.85;
-	PageRank cen(G, damp);
-	cen.run();
-	std::vector<std::pair<node, double>> ranking = cen.ranking();
-	INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
+    double damp = 0.85;
+    PageRank cen(G, damp);
+    cen.run();
+    std::vector<std::pair<node, double>> ranking = cen.ranking();
+    INFO("Highest rank: ", ranking[0].first, " with score ", ranking[0].second);
 }
 
 TEST_F(CentralityGTest, runEstimateBetweenness) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/celegans_metabolic.graph");
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
 
-	EstimateBetweenness abc2(G, 100);
-	abc2.run();
+    EstimateBetweenness abc2(G, 100);
+    abc2.run();
 
-	DEBUG("approximated betweenness scores: ", abc2.scores());
+    DEBUG("approximated betweenness scores: ", abc2.scores());
 }
 
 // FIXME look out for tolerance limit in paper sample nodes
 TEST_F(CentralityGTest, testApproxClosenessCentralityOnRealGraph) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/celegans_metabolic.graph");
+    METISGraphReader reader;
+    Graph G = reader.read("input/celegans_metabolic.graph");
 
-	ApproxCloseness acc(G, 453, 0, true);
-	acc.run();
+    ApproxCloseness acc(G, 453, 0, true);
+    acc.run();
 
-	std::vector<double> acc_scores = acc.scores();
+    std::vector<double> acc_scores = acc.scores();
 
-	ASSERT_EQ(acc_scores.size(), 453);
+    ASSERT_EQ(acc_scores.size(), 453);
 
-	// compare sampled approx closeness values vs real closeness values
-	// its a good compromise to not let the exact closness algorithm run
-	ASSERT_NEAR(acc_scores[0], 0.416206, 0.000001);
-	ASSERT_NEAR(acc_scores[10], 0.355906, 0.000001);
-	ASSERT_NEAR(acc_scores[87], 0.420465, 0.000001);
-	ASSERT_NEAR(acc_scores[121], 0.38865, 0.000001);
-	ASSERT_NEAR(acc_scores[178], 0.4, 0.000001);
-	ASSERT_NEAR(acc_scores[254], 0.397188, 0.000001);
-	ASSERT_NEAR(acc_scores[307], 0.398238, 0.000001);
-	ASSERT_NEAR(acc_scores[398], 0.37604, 0.000001);
-	ASSERT_NEAR(acc_scores[406], 0.360734, 0.000001);
-	ASSERT_NEAR(acc_scores[446], 0.396491, 0.000001);
+    // compare sampled approx closeness values vs real closeness values
+    // its a good compromise to not let the exact closness algorithm run
+    ASSERT_NEAR(acc_scores[0], 0.416206, 0.000001);
+    ASSERT_NEAR(acc_scores[10], 0.355906, 0.000001);
+    ASSERT_NEAR(acc_scores[87], 0.420465, 0.000001);
+    ASSERT_NEAR(acc_scores[121], 0.38865, 0.000001);
+    ASSERT_NEAR(acc_scores[178], 0.4, 0.000001);
+    ASSERT_NEAR(acc_scores[254], 0.397188, 0.000001);
+    ASSERT_NEAR(acc_scores[307], 0.398238, 0.000001);
+    ASSERT_NEAR(acc_scores[398], 0.37604, 0.000001);
+    ASSERT_NEAR(acc_scores[406], 0.360734, 0.000001);
+    ASSERT_NEAR(acc_scores[446], 0.396491, 0.000001);
 }
 
 TEST_F(CentralityGTest, testApproxClosenessCentralityOnToyGraph) {
-	/* Graph:
-	 0    3
-	  \  / \
-	   2    5
-	  /  \ /
-	 1    4
-	*/
-	count n = 6;
-	Graph G(n);
+    /* Graph:
+     0    3
+      \  / \
+       2    5
+      /  \ /
+     1    4
+    */
+    count n = 6;
+    Graph G(n);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
 
-	ApproxCloseness acc(G, 6, 0.1, false);
-	acc.run();
-	std::vector<double> cc = acc.scores();
+    ApproxCloseness acc(G, 6, 0.1, false);
+    acc.run();
+    std::vector<double> cc = acc.scores();
 
-	double maximum = acc.maximum();
+    double maximum = acc.maximum();
 
-	const double tol = 0.2;
-	EXPECT_NEAR(0.1, cc[0], tol);
-	EXPECT_NEAR(0.1, cc[1], tol);
-	EXPECT_NEAR(0.166667, cc[2], tol);
-	EXPECT_NEAR(0.125, cc[3], tol);
-	EXPECT_NEAR(0.125, cc[4], tol);
-	EXPECT_NEAR(0.1, cc[5], tol);
-	EXPECT_NEAR(0.2, maximum, tol);
+    const double tol = 0.2;
+    EXPECT_NEAR(0.1, cc[0], tol);
+    EXPECT_NEAR(0.1, cc[1], tol);
+    EXPECT_NEAR(0.166667, cc[2], tol);
+    EXPECT_NEAR(0.125, cc[3], tol);
+    EXPECT_NEAR(0.125, cc[4], tol);
+    EXPECT_NEAR(0.1, cc[5], tol);
+    EXPECT_NEAR(0.2, maximum, tol);
 
-	ApproxCloseness acc2(G, 4, 0.1, true);
-	acc2.run();
-	std::vector<double> cc2 = acc2.scores();
+    ApproxCloseness acc2(G, 4, 0.1, true);
+    acc2.run();
+    std::vector<double> cc2 = acc2.scores();
 
-	double maximum2 = acc2.maximum();
+    double maximum2 = acc2.maximum();
 
-	EXPECT_NEAR(0.5, cc2[0], tol);
-	EXPECT_NEAR(0.5, cc2[1], tol);
-	EXPECT_NEAR(0.833335, cc2[2], tol);
-	EXPECT_NEAR(0.625, cc2[3], tol);
-	EXPECT_NEAR(0.625, cc2[4], tol);
-	EXPECT_NEAR(0.5, cc2[5], tol);
-	EXPECT_NEAR(0.2, maximum2, tol);
+    EXPECT_NEAR(0.5, cc2[0], tol);
+    EXPECT_NEAR(0.5, cc2[1], tol);
+    EXPECT_NEAR(0.833335, cc2[2], tol);
+    EXPECT_NEAR(0.625, cc2[3], tol);
+    EXPECT_NEAR(0.625, cc2[4], tol);
+    EXPECT_NEAR(0.5, cc2[5], tol);
+    EXPECT_NEAR(0.2, maximum2, tol);
 }
 
 TEST_F(CentralityGTest, testEdgeBetweennessCentrality) {
-	/* Graph:
-	 0    3
-	  \  / \
-	   2    5
-	  /  \ /
-	 1    4
-	*/
-	count n = 6;
-	Graph G(n);
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
-	G.indexEdges();
+    /* Graph:
+     0    3
+      \  / \
+       2    5
+      /  \ /
+     1    4
+    */
+    count n = 6;
+    Graph G(n);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
+    G.indexEdges();
 
-	Betweenness centrality(G, false, true);
-	centrality.run();
-	std::vector<double> bc = centrality.edgeScores();
+    Betweenness centrality(G, false, true);
+    centrality.run();
+    std::vector<double> bc = centrality.edgeScores();
 
-	const double tol = 1e-3;
-	EXPECT_NEAR(10.0, bc[0], tol);
-	EXPECT_NEAR(10.0, bc[1], tol);
-	EXPECT_NEAR(10.0, bc[2], tol);
-	EXPECT_NEAR(10.0, bc[3], tol);
-	EXPECT_NEAR(6.0, bc[4], tol);
-	EXPECT_NEAR(6.0, bc[5], tol);
+    const double tol = 1e-3;
+    EXPECT_NEAR(10.0, bc[0], tol);
+    EXPECT_NEAR(10.0, bc[1], tol);
+    EXPECT_NEAR(10.0, bc[2], tol);
+    EXPECT_NEAR(10.0, bc[3], tol);
+    EXPECT_NEAR(6.0, bc[4], tol);
+    EXPECT_NEAR(6.0, bc[5], tol);
 }
 
 TEST_F(CentralityGTest, debugEdgeBetweennessCentrality) {
-	auto path = "input/PGPgiantcompo.graph";
-	METISGraphReader reader;
-	Graph G = reader.read(path);
-	G.indexEdges();
+    auto path = "input/PGPgiantcompo.graph";
+    METISGraphReader reader;
+    Graph G = reader.read(path);
+    G.indexEdges();
 
-	Betweenness centrality(G, false, true);
-	centrality.run();
-	std::vector<double> bc = centrality.edgeScores();
+    Betweenness centrality(G, false, true);
+    centrality.run();
+    std::vector<double> bc = centrality.edgeScores();
 }
 
 TEST_F(CentralityGTest, testClosenessCentrality) {
-	/* Graph:
-	 0    3
-	  \  / \
-	   2    5
-	  /  \ /
-	 1    4
-	*/
-	count n = 6;
-	Graph G(n);
+    /* Graph:
+     0    3
+      \  / \
+       2    5
+      /  \ /
+     1    4
+    */
+    count n = 6;
+    Graph G(n);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
 
-	Closeness centrality(G, false, ClosenessVariant::generalized);
-	centrality.run();
-	std::vector<double> bc = centrality.scores();
+    Closeness centrality(G, false, ClosenessVariant::generalized);
+    centrality.run();
+    std::vector<double> bc = centrality.scores();
 
-	double maximum = centrality.maximum();
+    double maximum = centrality.maximum();
 
-	const double tol = 1e-3;
-	EXPECT_NEAR(0.1, bc[0], tol);
-	EXPECT_NEAR(0.1, bc[1], tol);
-	EXPECT_NEAR(0.166667, bc[2], tol);
-	EXPECT_NEAR(0.125, bc[3], tol);
-	EXPECT_NEAR(0.125, bc[4], tol);
-	EXPECT_NEAR(0.1, bc[5], tol);
-	EXPECT_NEAR(0.2, maximum, tol);
+    const double tol = 1e-3;
+    EXPECT_NEAR(0.1, bc[0], tol);
+    EXPECT_NEAR(0.1, bc[1], tol);
+    EXPECT_NEAR(0.166667, bc[2], tol);
+    EXPECT_NEAR(0.125, bc[3], tol);
+    EXPECT_NEAR(0.125, bc[4], tol);
+    EXPECT_NEAR(0.1, bc[5], tol);
+    EXPECT_NEAR(0.2, maximum, tol);
+}
+
+TEST_F(CentralityGTest, testClosenessCentralityWeighted) {
+    /* Graph:
+     0    3
+      \  / \
+       2    5
+      /  \ /
+     1    4
+    */
+    count n = 6;
+    Graph G(n);
+    Graph Gw(n, true, false);
+
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
+    G.forEdges([&](node u, node v) { Gw.addEdge(u, v, 1.); });
+
+    Closeness centrality(G, false, ClosenessVariant::generalized);
+    Closeness cw(Gw, false, ClosenessVariant::generalized);
+    centrality.run();
+    cw.run();
+
+    auto bc = centrality.scores();
+    auto bc_ = centrality.scores();
+
+    const double tol = 1e-6;
+    for (node u = 0; u < n; ++u) {
+        EXPECT_NEAR(bc[u], bc_[u], tol);
+    }
 }
 
 TEST_F(CentralityGTest, testClosenessCentralityDirected) {
-	/* Graph:
-	 0    3
-	  \  / \
-	   2    5
-	  /  \ /
-	 1    4
-	*/
-	count n = 6;
-	Graph G(n, false, true);
+    /* Graph:
+     0    3
+      \  / \
+       2    5
+      /  \ /
+     1    4
+    */
+    count n = 6;
+    Graph G(n, false, true);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
 
-	Closeness centrality(G, true, ClosenessVariant::generalized);
-	centrality.run();
-	std::vector<double> bc = centrality.scores();
+    Closeness centrality(G, true, ClosenessVariant::generalized);
+    centrality.run();
+    std::vector<double> bc = centrality.scores();
 
-	double maximum = centrality.maximum();
+    double maximum = centrality.maximum();
 
-	const double tol = 1e-6;
-	EXPECT_NEAR(0.4, bc[0], tol);
-	EXPECT_NEAR(0.4, bc[1], tol);
-	EXPECT_NEAR(0.45, bc[2], tol);
-	EXPECT_NEAR(0.2, bc[3], tol);
-	EXPECT_NEAR(0.2, bc[4], tol);
-	EXPECT_NEAR(0, bc[5], tol);
+    const double tol = 1e-6;
+    EXPECT_NEAR(0.4, bc[0], tol);
+    EXPECT_NEAR(0.4, bc[1], tol);
+    EXPECT_NEAR(0.45, bc[2], tol);
+    EXPECT_NEAR(0.2, bc[3], tol);
+    EXPECT_NEAR(0.2, bc[4], tol);
+    EXPECT_NEAR(0, bc[5], tol);
 }
 
 TEST_F(CentralityGTest, testHarmonicClosenessCentrality) {
-	/* Graph:
-	 0    3
-	  \  / \
-	   2    5
-	  /  \ /
-	 1    4
-	*/
-	count n = 6;
-	Graph G(n);
+    /* Graph:
+     0    3
+      \  / \
+       2    5
+      /  \ /
+     1    4
+    */
+    count n = 6;
+    Graph G(n);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
 
-	HarmonicCloseness centrality(G, false);
-	centrality.run();
-	std::vector<double> hc = centrality.scores();
+    HarmonicCloseness centrality(G, false);
+    centrality.run();
+    std::vector<double> hc = centrality.scores();
 
-	double maximum = centrality.maximum();
+    double maximum = centrality.maximum();
 
-	const double tol = 1e-3;
-	EXPECT_NEAR(2.833, hc[0], tol);
-	EXPECT_NEAR(2.833, hc[1], tol);
-	EXPECT_NEAR(4.5, hc[2], tol);
-	EXPECT_NEAR(3.5, hc[3], tol);
-	EXPECT_NEAR(3.5, hc[4], tol);
-	EXPECT_NEAR(3.1667, hc[5], tol);
-	EXPECT_NEAR(1, maximum, tol);
+    const double tol = 1e-3;
+    EXPECT_NEAR(2.833, hc[0], tol);
+    EXPECT_NEAR(2.833, hc[1], tol);
+    EXPECT_NEAR(4.5, hc[2], tol);
+    EXPECT_NEAR(3.5, hc[3], tol);
+    EXPECT_NEAR(3.5, hc[4], tol);
+    EXPECT_NEAR(3.1667, hc[5], tol);
+    EXPECT_NEAR(1, maximum, tol);
 }
 
 TEST_F(CentralityGTest, runKPathCentrality) {
-	METISGraphReader reader;
-	Graph G = reader.read("input/lesmis.graph");
+    METISGraphReader reader;
+    Graph G = reader.read("input/lesmis.graph");
 
-	KPathCentrality centrality(G);
-	centrality.run();
+    KPathCentrality centrality(G);
+    centrality.run();
 }
 
 TEST_F(CentralityGTest, testCoreDecompositionSimple) {
-	count n = 3;
-	Graph G(n);
-	G.addEdge(0, 1);
+    count n = 3;
+    Graph G(n);
+    G.addEdge(0, 1);
 
-	CoreDecomposition coreDec(G);
-	coreDec.run();
-	std::vector<double> coreness = coreDec.scores();
+    CoreDecomposition coreDec(G);
+    coreDec.run();
+    std::vector<double> coreness = coreDec.scores();
 
-	EXPECT_EQ(1u, coreness[0]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[1]) << "expected coreness";
-	EXPECT_EQ(0u, coreness[2]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[0]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[1]) << "expected coreness";
+    EXPECT_EQ(0u, coreness[2]) << "expected coreness";
 }
 
 TEST_F(CentralityGTest, testCoreDecomposition) {
-	count n = 16;
-	Graph G(n);
+    count n = 16;
+    Graph G(n);
 
-	// 	// create graph used in Baur et al. and network analysis lecture
-	G.addEdge(2, 4);
-	G.addEdge(3, 4);
-	G.addEdge(4, 5);
-	G.addEdge(5, 7);
-	G.addEdge(6, 7);
+    // 	// create graph used in Baur et al. and network analysis lecture
+    G.addEdge(2, 4);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(5, 7);
+    G.addEdge(6, 7);
 
-	G.addEdge(6, 8);
-	G.addEdge(6, 9);
-	G.addEdge(6, 11);
-	G.addEdge(7, 12);
-	G.addEdge(8, 9);
+    G.addEdge(6, 8);
+    G.addEdge(6, 9);
+    G.addEdge(6, 11);
+    G.addEdge(7, 12);
+    G.addEdge(8, 9);
 
-	G.addEdge(8, 10);
-	G.addEdge(8, 11);
-	G.addEdge(8, 13);
-	G.addEdge(9, 10);
-	G.addEdge(9, 11);
+    G.addEdge(8, 10);
+    G.addEdge(8, 11);
+    G.addEdge(8, 13);
+    G.addEdge(9, 10);
+    G.addEdge(9, 11);
 
-	G.addEdge(9, 13);
-	G.addEdge(10, 11);
-	G.addEdge(10, 13);
-	G.addEdge(10, 14);
-	G.addEdge(11, 13);
+    G.addEdge(9, 13);
+    G.addEdge(10, 11);
+    G.addEdge(10, 13);
+    G.addEdge(10, 14);
+    G.addEdge(11, 13);
 
-	G.addEdge(11, 14);
-	G.addEdge(12, 15);
-	G.addEdge(13, 14);
-	G.addEdge(14, 15);
+    G.addEdge(11, 14);
+    G.addEdge(12, 15);
+    G.addEdge(13, 14);
+    G.addEdge(14, 15);
 
-	EXPECT_EQ(n, G.numberOfNodes()) << "should have " << n << " vertices";
-	EXPECT_EQ(24u, G.numberOfEdges()) << "should have 24 edges";
+    EXPECT_EQ(n, G.numberOfNodes()) << "should have " << n << " vertices";
+    EXPECT_EQ(24u, G.numberOfEdges()) << "should have 24 edges";
 
-	// compute core decomposition
-	CoreDecomposition coreDec(G);
-	coreDec.run();
-	std::vector<double> coreness = coreDec.scores();
-	// init cores
-	// init shells
-	Cover cores = coreDec.getCover();
-	Partition shells = coreDec.getPartition();
+    // compute core decomposition
+    CoreDecomposition coreDec(G);
+    coreDec.run();
+    std::vector<double> coreness = coreDec.scores();
+    // init cores
+    // init shells
+    Cover cores = coreDec.getCover();
+    Partition shells = coreDec.getPartition();
 
-	EXPECT_EQ(0u, coreness[0]) << "expected coreness";
-	EXPECT_EQ(0u, coreness[1]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[2]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[3]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[4]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[5]) << "expected coreness";
-	EXPECT_EQ(3u, coreness[6]) << "expected coreness";
-	EXPECT_EQ(2u, coreness[7]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[8]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[9]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[10]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[11]) << "expected coreness";
-	EXPECT_EQ(2u, coreness[12]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[13]) << "expected coreness";
-	EXPECT_EQ(3u, coreness[14]) << "expected coreness";
-	EXPECT_EQ(2u, coreness[15]) << "expected coreness";
+    EXPECT_EQ(0u, coreness[0]) << "expected coreness";
+    EXPECT_EQ(0u, coreness[1]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[2]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[3]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[4]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[5]) << "expected coreness";
+    EXPECT_EQ(3u, coreness[6]) << "expected coreness";
+    EXPECT_EQ(2u, coreness[7]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[8]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[9]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[10]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[11]) << "expected coreness";
+    EXPECT_EQ(2u, coreness[12]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[13]) << "expected coreness";
+    EXPECT_EQ(3u, coreness[14]) << "expected coreness";
+    EXPECT_EQ(2u, coreness[15]) << "expected coreness";
 
-	// for (index e = 0; e < n; e++) {
-	// 	EXPECT_EQ(cores.contains(e), true);
-	// 	EXPECT_EQ(shells.contains(e), true);
-	// }
-	// EXPECT_EQ(cores.get, coreness[15]) << "expected coreness";
+    // for (index e = 0; e < n; e++) {
+    // 	EXPECT_EQ(cores.contains(e), true);
+    // 	EXPECT_EQ(shells.contains(e), true);
+    // }
+    // EXPECT_EQ(cores.get, coreness[15]) << "expected coreness";
 
-	// test throw runtime error for self-loop in graph
-	Graph H(2);
-	H.addEdge(0, 1);
-	H.addEdge(1, 1);
-	EXPECT_ANY_THROW(CoreDecomposition CoreDec(H));
+    // test throw runtime error for self-loop in graph
+    Graph H(2);
+    H.addEdge(0, 1);
+    H.addEdge(1, 1);
+    EXPECT_ANY_THROW(CoreDecomposition CoreDec(H));
 }
 
 TEST_F(CentralityGTest, benchCoreDecompositionLocal) {
-	METISGraphReader reader;
-	std::vector<std::string> filenames = {"caidaRouterLevel", "wing", "astro-ph",
-	                                      "PGPgiantcompo"};
+    METISGraphReader reader;
+    std::vector<std::string> filenames = {"caidaRouterLevel", "wing",
+                                          "astro-ph", "PGPgiantcompo"};
 
-	for (auto f : filenames) {
-		std::string filename("input/" + f + ".graph");
-		DEBUG("about to read file ", filename);
-		Graph G = reader.read(filename);
-		G.removeSelfLoops();
-		CoreDecomposition coreDec(G, false);
-		Aux::Timer timer;
-		timer.start();
-		coreDec.run();
-		timer.stop();
-		INFO("Time for ParK of ", filename, ": ", timer.elapsedTag());
+    for (auto f : filenames) {
+        std::string filename("input/" + f + ".graph");
+        DEBUG("about to read file ", filename);
+        Graph G = reader.read(filename);
+        G.removeSelfLoops();
+        CoreDecomposition coreDec(G, false);
+        Aux::Timer timer;
+        timer.start();
+        coreDec.run();
+        timer.stop();
+        INFO("Time for ParK of ", filename, ": ", timer.elapsedTag());
 
-		CoreDecomposition coreDec2(G, true);
-		timer.start();
-		coreDec2.run();
-		timer.stop();
-		INFO("Time for bucket queue based k-core decomposition of ", filename, ": ",
-		     timer.elapsedTag());
+        CoreDecomposition coreDec2(G, true);
+        timer.start();
+        coreDec2.run();
+        timer.stop();
+        INFO("Time for bucket queue based k-core decomposition of ", filename,
+             ": ", timer.elapsedTag());
 
-		G.forNodes([&](node u) { EXPECT_EQ(coreDec.score(u), coreDec2.score(u)); });
-	}
+        G.forNodes(
+            [&](node u) { EXPECT_EQ(coreDec.score(u), coreDec2.score(u)); });
+    }
 }
 
 TEST_F(CentralityGTest, testCoreDecompositionDirected) {
-	count n = 16;
-	Graph G(n, false, true);
+    count n = 16;
+    Graph G(n, false, true);
 
-	// 	// create graph used in Baur et al. and network analysis lecture
-	G.addEdge(2, 4);
-	G.addEdge(3, 4);
-	G.addEdge(4, 5);
-	G.addEdge(5, 7);
-	G.addEdge(6, 7);
+    // 	// create graph used in Baur et al. and network analysis lecture
+    G.addEdge(2, 4);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(5, 7);
+    G.addEdge(6, 7);
 
-	G.addEdge(6, 8);
-	G.addEdge(6, 9);
-	G.addEdge(6, 11);
-	G.addEdge(7, 12);
-	G.addEdge(8, 9);
+    G.addEdge(6, 8);
+    G.addEdge(6, 9);
+    G.addEdge(6, 11);
+    G.addEdge(7, 12);
+    G.addEdge(8, 9);
 
-	G.addEdge(8, 10);
-	G.addEdge(8, 11);
-	G.addEdge(8, 13);
-	G.addEdge(9, 10);
-	G.addEdge(9, 11);
+    G.addEdge(8, 10);
+    G.addEdge(8, 11);
+    G.addEdge(8, 13);
+    G.addEdge(9, 10);
+    G.addEdge(9, 11);
 
-	G.addEdge(9, 13);
-	G.addEdge(10, 11);
-	G.addEdge(10, 13);
-	G.addEdge(10, 14);
-	G.addEdge(11, 13);
+    G.addEdge(9, 13);
+    G.addEdge(10, 11);
+    G.addEdge(10, 13);
+    G.addEdge(10, 14);
+    G.addEdge(11, 13);
 
-	G.addEdge(11, 14);
-	G.addEdge(12, 15);
-	G.addEdge(13, 14);
-	G.addEdge(14, 15);
+    G.addEdge(11, 14);
+    G.addEdge(12, 15);
+    G.addEdge(13, 14);
+    G.addEdge(14, 15);
 
-	EXPECT_EQ(n, G.numberOfNodes()) << "should have " << n << " vertices";
-	EXPECT_EQ(24u, G.numberOfEdges()) << "should have 24 edges";
+    EXPECT_EQ(n, G.numberOfNodes()) << "should have " << n << " vertices";
+    EXPECT_EQ(24u, G.numberOfEdges()) << "should have 24 edges";
 
-	// compute core decomposition
-	CoreDecomposition coreDec(G);
-	coreDec.run();
-	std::vector<double> coreness = coreDec.scores();
+    // compute core decomposition
+    CoreDecomposition coreDec(G);
+    coreDec.run();
+    std::vector<double> coreness = coreDec.scores();
 
-	EXPECT_EQ(0u, coreness[0]) << "expected coreness";
-	EXPECT_EQ(0u, coreness[1]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[2]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[3]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[4]) << "expected coreness";
-	EXPECT_EQ(1u, coreness[5]) << "expected coreness";
-	EXPECT_EQ(3u, coreness[6]) << "expected coreness";
-	EXPECT_EQ(2u, coreness[7]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[8]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[9]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[10]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[11]) << "expected coreness";
-	EXPECT_EQ(2u, coreness[12]) << "expected coreness";
-	EXPECT_EQ(4u, coreness[13]) << "expected coreness";
-	EXPECT_EQ(3u, coreness[14]) << "expected coreness";
-	EXPECT_EQ(2u, coreness[15]) << "expected coreness";
+    EXPECT_EQ(0u, coreness[0]) << "expected coreness";
+    EXPECT_EQ(0u, coreness[1]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[2]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[3]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[4]) << "expected coreness";
+    EXPECT_EQ(1u, coreness[5]) << "expected coreness";
+    EXPECT_EQ(3u, coreness[6]) << "expected coreness";
+    EXPECT_EQ(2u, coreness[7]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[8]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[9]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[10]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[11]) << "expected coreness";
+    EXPECT_EQ(2u, coreness[12]) << "expected coreness";
+    EXPECT_EQ(4u, coreness[13]) << "expected coreness";
+    EXPECT_EQ(3u, coreness[14]) << "expected coreness";
+    EXPECT_EQ(2u, coreness[15]) << "expected coreness";
 }
 
 TEST_F(CentralityGTest, testLocalClusteringCoefficientUndirected) {
-	count n = 16;
-	Graph G(n, false, false);
+    count n = 16;
+    Graph G(n, false, false);
 
-	// 	// create graph used in Baur et al. and network analysis lecture
-	G.addEdge(2, 4);
-	G.addEdge(3, 4);
-	G.addEdge(4, 5);
-	G.addEdge(5, 7);
-	G.addEdge(6, 7);
+    // 	// create graph used in Baur et al. and network analysis lecture
+    G.addEdge(2, 4);
+    G.addEdge(3, 4);
+    G.addEdge(4, 5);
+    G.addEdge(5, 7);
+    G.addEdge(6, 7);
 
-	G.addEdge(6, 8);
-	G.addEdge(6, 9);
-	G.addEdge(6, 11);
-	G.addEdge(7, 12);
-	G.addEdge(8, 9);
+    G.addEdge(6, 8);
+    G.addEdge(6, 9);
+    G.addEdge(6, 11);
+    G.addEdge(7, 12);
+    G.addEdge(8, 9);
 
-	G.addEdge(8, 10);
-	G.addEdge(8, 11);
-	G.addEdge(8, 13);
-	G.addEdge(9, 10);
-	G.addEdge(9, 11);
+    G.addEdge(8, 10);
+    G.addEdge(8, 11);
+    G.addEdge(8, 13);
+    G.addEdge(9, 10);
+    G.addEdge(9, 11);
 
-	G.addEdge(9, 13);
-	G.addEdge(10, 11);
-	G.addEdge(10, 13);
-	G.addEdge(10, 14);
-	G.addEdge(11, 13);
+    G.addEdge(9, 13);
+    G.addEdge(10, 11);
+    G.addEdge(10, 13);
+    G.addEdge(10, 14);
+    G.addEdge(11, 13);
 
-	G.addEdge(11, 14);
-	G.addEdge(12, 15);
-	G.addEdge(13, 14);
-	G.addEdge(14, 15);
+    G.addEdge(11, 14);
+    G.addEdge(12, 15);
+    G.addEdge(13, 14);
+    G.addEdge(14, 15);
 
-	EXPECT_EQ(n, G.numberOfNodes()) << "should have " << n << " vertices";
-	EXPECT_EQ(24u, G.numberOfEdges()) << "should have 24 edges";
+    EXPECT_EQ(n, G.numberOfNodes()) << "should have " << n << " vertices";
+    EXPECT_EQ(24u, G.numberOfEdges()) << "should have 24 edges";
 
-	// compute core decomposition
-	LocalClusteringCoefficient lcc(G);
-	lcc.run();
-	std::vector<double> lccScores = lcc.scores();
-	std::vector<double> reference = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-	                                 0.5, 0.0, 0.8, 0.8, 0.8, 0.6666666666666666,
-	                                 0.0, 0.8, 0.5, 0.0};
+    // compute core decomposition
+    LocalClusteringCoefficient lcc(G);
+    lcc.run();
+    std::vector<double> lccScores = lcc.scores();
+    std::vector<double> reference = {0.0, 0.0, 0.0, 0.0,
+                                     0.0, 0.0, 0.5, 0.0,
+                                     0.8, 0.8, 0.8, 0.6666666666666666,
+                                     0.0, 0.8, 0.5, 0.0};
 
-	EXPECT_EQ(reference, lccScores);
+    EXPECT_EQ(reference, lccScores);
 
-	LocalClusteringCoefficient lccTurbo(G, true);
-	lccTurbo.run();
-	EXPECT_EQ(reference, lccTurbo.scores());
+    LocalClusteringCoefficient lccTurbo(G, true);
+    lccTurbo.run();
+    EXPECT_EQ(reference, lccTurbo.scores());
 
-	// test throw runtime error for self-loop in graph
-	Graph H(2);
-	H.addEdge(0, 1);
-	H.addEdge(1, 1);
-	EXPECT_ANY_THROW(LocalClusteringCoefficient lcc(H));
+    // test throw runtime error for self-loop in graph
+    Graph H(2);
+    H.addEdge(0, 1);
+    H.addEdge(1, 1);
+    EXPECT_ANY_THROW(LocalClusteringCoefficient lcc(H));
 }
 
 TEST_F(CentralityGTest, testLocalClusteringCoefficientUndirected2) {
-	Graph G(6, false, false);
-	G.addEdge(1, 0);
-	G.addEdge(2, 0);
-	G.addEdge(2, 1);
-	G.addEdge(3, 2);
-	G.addEdge(3, 0);
-	G.addEdge(3, 1);
-	G.addEdge(4, 2);
-	G.addEdge(4, 0);
-	G.addEdge(5, 3);
-	G.addEdge(5, 4);
-	G.addEdge(5, 1);
-	LocalClusteringCoefficient lcc(G);
-	lcc.run();
-	std::vector<double> lccScores = lcc.scores();
-	std::vector<double> reference = {0.6666666666666666, 0.6666666666666666,
-	                                 0.6666666666666666, 0.6666666666666666,
-	                                 0.3333333333333333, 0.3333333333333333};
+    Graph G(6, false, false);
+    G.addEdge(1, 0);
+    G.addEdge(2, 0);
+    G.addEdge(2, 1);
+    G.addEdge(3, 2);
+    G.addEdge(3, 0);
+    G.addEdge(3, 1);
+    G.addEdge(4, 2);
+    G.addEdge(4, 0);
+    G.addEdge(5, 3);
+    G.addEdge(5, 4);
+    G.addEdge(5, 1);
+    LocalClusteringCoefficient lcc(G);
+    lcc.run();
+    std::vector<double> lccScores = lcc.scores();
+    std::vector<double> reference = {0.6666666666666666, 0.6666666666666666,
+                                     0.6666666666666666, 0.6666666666666666,
+                                     0.3333333333333333, 0.3333333333333333};
 
-	EXPECT_EQ(reference, lccScores);
+    EXPECT_EQ(reference, lccScores);
 }
 
 TEST_F(CentralityGTest, testSimplePermanence) {
-	Graph G(15, false, false);
-	G.addEdge(0, 1);
-	G.addEdge(1, 2);
-	G.addEdge(2, 0);
-	G.addEdge(2, 3);
-	node v = 4;
-	node u = 5;
-	G.addEdge(v, 0);
-	G.addEdge(v, 1);
-	G.addEdge(v, 2);
-	G.addEdge(u, 3);
-	G.addEdge(u, 2);
-	G.addEdge(u, 0);
-	G.addEdge(6, 7);
-	G.addEdge(7, 8);
-	G.addEdge(u, 6);
-	G.addEdge(u, 7);
-	G.addEdge(u, 8);
-	G.addEdge(v, 6);
-	G.addEdge(v, 7);
-	G.addEdge(9, 10);
-	G.addEdge(10, 11);
-	G.addEdge(u, 9);
-	G.addEdge(v, 10);
-	G.addEdge(v, 11);
-	G.addEdge(12, 13);
-	G.addEdge(13, 14);
-	G.addEdge(12, 14);
-	G.addEdge(v, 12);
-	G.addEdge(v, 14);
+    Graph G(15, false, false);
+    G.addEdge(0, 1);
+    G.addEdge(1, 2);
+    G.addEdge(2, 0);
+    G.addEdge(2, 3);
+    node v = 4;
+    node u = 5;
+    G.addEdge(v, 0);
+    G.addEdge(v, 1);
+    G.addEdge(v, 2);
+    G.addEdge(u, 3);
+    G.addEdge(u, 2);
+    G.addEdge(u, 0);
+    G.addEdge(6, 7);
+    G.addEdge(7, 8);
+    G.addEdge(u, 6);
+    G.addEdge(u, 7);
+    G.addEdge(u, 8);
+    G.addEdge(v, 6);
+    G.addEdge(v, 7);
+    G.addEdge(9, 10);
+    G.addEdge(10, 11);
+    G.addEdge(u, 9);
+    G.addEdge(v, 10);
+    G.addEdge(v, 11);
+    G.addEdge(12, 13);
+    G.addEdge(13, 14);
+    G.addEdge(12, 14);
+    G.addEdge(v, 12);
+    G.addEdge(v, 14);
 
-	Partition P(G.upperNodeIdBound());
-	P.setUpperBound(4);
-	P[0] = 0;
-	P[1] = 0;
-	P[2] = 0;
-	P[3] = 0;
-	P[v] = 0;
-	P[u] = 0;
-	P[6] = 1;
-	P[7] = 1;
-	P[8] = 1;
-	P[9] = 2;
-	P[10] = 2;
-	P[11] = 2;
-	P[12] = 3;
-	P[13] = 3;
-	P[14] = 3;
+    Partition P(G.upperNodeIdBound());
+    P.setUpperBound(4);
+    P[0] = 0;
+    P[1] = 0;
+    P[2] = 0;
+    P[3] = 0;
+    P[v] = 0;
+    P[u] = 0;
+    P[6] = 1;
+    P[7] = 1;
+    P[8] = 1;
+    P[9] = 2;
+    P[10] = 2;
+    P[11] = 2;
+    P[12] = 3;
+    P[13] = 3;
+    P[14] = 3;
 
-	ASSERT_EQ(9u, G.degree(v));
-	ASSERT_EQ(7u, G.degree(u));
+    ASSERT_EQ(9u, G.degree(v));
+    ASSERT_EQ(7u, G.degree(u));
 
-	PermanenceCentrality perm(G, P);
-	perm.run();
-	EXPECT_DOUBLE_EQ(2.0 / 3.0, perm.getIntraClustering(u));
-	EXPECT_DOUBLE_EQ(1, perm.getIntraClustering(v));
+    PermanenceCentrality perm(G, P);
+    perm.run();
+    EXPECT_DOUBLE_EQ(2.0 / 3.0, perm.getIntraClustering(u));
+    EXPECT_DOUBLE_EQ(1, perm.getIntraClustering(v));
 
-	EXPECT_NEAR(-0.19048, perm.getPermanence(u), 0.0005);
-	EXPECT_NEAR(0.167, perm.getPermanence(v), 0.0005);
+    EXPECT_NEAR(-0.19048, perm.getPermanence(u), 0.0005);
+    EXPECT_NEAR(0.167, perm.getPermanence(v), 0.0005);
 }
 
 TEST_F(CentralityGTest, testTopClosenessDirected) {
-	count size = 400;
-	count k = 10;
-	Graph G1 = DorogovtsevMendesGenerator(size).generate();
-	Graph G(G1.upperNodeIdBound(), false, true);
-	G1.forEdges([&](node u, node v) {
-		G.addEdge(u, v);
-		G.addEdge(v, u);
-	});
-	Closeness cc(G1, true, ClosenessVariant::generalized);
-	cc.run();
-	TopCloseness topcc(G, k, true, true);
-	topcc.run();
-	const edgeweight tol = 1e-7;
-	for (count i = 0; i < k; i++) {
-		EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
-	}
-	TopCloseness topcc2(G, k, true, false);
-	topcc2.run();
-	for (count i = 0; i < k; i++) {
-		EXPECT_NEAR(cc.ranking()[i].second, topcc2.topkScoresList()[i], tol);
-	}
+    count size = 400;
+    count k = 10;
+    Graph G1 = DorogovtsevMendesGenerator(size).generate();
+    Graph G(G1.upperNodeIdBound(), false, true);
+    G1.forEdges([&](node u, node v) {
+        G.addEdge(u, v);
+        G.addEdge(v, u);
+    });
+    Closeness cc(G1, true, ClosenessVariant::generalized);
+    cc.run();
+    TopCloseness topcc(G, k, true, true);
+    topcc.run();
+    const edgeweight tol = 1e-7;
+    for (count i = 0; i < k; i++) {
+        EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
+    }
+    TopCloseness topcc2(G, k, true, false);
+    topcc2.run();
+    for (count i = 0; i < k; i++) {
+        EXPECT_NEAR(cc.ranking()[i].second, topcc2.topkScoresList()[i], tol);
+    }
 }
 
 TEST_F(CentralityGTest, testTopClosenessUndirected) {
-	count size = 400;
-	count k = 10;
-	Graph G1 = DorogovtsevMendesGenerator(size).generate();
-	Graph G(G1.upperNodeIdBound(), false, false);
-	G1.forEdges([&](node u, node v) {
-		G.addEdge(u, v);
-		G.addEdge(v, u);
-	});
-	Closeness cc(G1, true, ClosenessVariant::generalized);
-	cc.run();
-	TopCloseness topcc(G, k, true, true);
-	topcc.run();
-	const edgeweight tol = 1e-7;
-	for (count i = 0; i < k; i++) {
-		EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
-	}
-	TopCloseness topcc2(G, k, true, false);
-	topcc2.run();
-	for (count i = 0; i < k; i++) {
-		EXPECT_NEAR(cc.ranking()[i].second, topcc2.topkScoresList()[i], tol);
-	}
+    count size = 400;
+    count k = 10;
+    Graph G1 = DorogovtsevMendesGenerator(size).generate();
+    Graph G(G1.upperNodeIdBound(), false, false);
+    G1.forEdges([&](node u, node v) {
+        G.addEdge(u, v);
+        G.addEdge(v, u);
+    });
+    Closeness cc(G1, true, ClosenessVariant::generalized);
+    cc.run();
+    TopCloseness topcc(G, k, true, true);
+    topcc.run();
+    const edgeweight tol = 1e-7;
+    for (count i = 0; i < k; i++) {
+        EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
+    }
+    TopCloseness topcc2(G, k, true, false);
+    topcc2.run();
+    for (count i = 0; i < k; i++) {
+        EXPECT_NEAR(cc.ranking()[i].second, topcc2.topkScoresList()[i], tol);
+    }
 }
 
 TEST_F(CentralityGTest, testTopHarmonicClosenessDirected) {
-	count size = 400;
-	count k = 10;
-	Graph G1 = DorogovtsevMendesGenerator(size).generate();
-	Graph G(G1.upperNodeIdBound(), false, true);
-	G1.forEdges([&](node u, node v) {
-		G.addEdge(u, v);
-		G.addEdge(v, u);
-	});
-	HarmonicCloseness cc(G1, false);
-	cc.run();
-	TopHarmonicCloseness topcc(G, k);
-	topcc.run();
-	const edgeweight tol = 1e-7;
-	for (count i = 0; i < k; i++) {
-		EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
-	}
+    count size = 400;
+    count k = 10;
+    Graph G1 = DorogovtsevMendesGenerator(size).generate();
+    Graph G(G1.upperNodeIdBound(), false, true);
+    G1.forEdges([&](node u, node v) {
+        G.addEdge(u, v);
+        G.addEdge(v, u);
+    });
+    HarmonicCloseness cc(G1, false);
+    cc.run();
+    TopHarmonicCloseness topcc(G, k);
+    topcc.run();
+    const edgeweight tol = 1e-7;
+    for (count i = 0; i < k; i++) {
+        EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
+    }
 }
 
 TEST_F(CentralityGTest, testTopHarmonicClosenessUndirected) {
-	count size = 400;
-	count k = 10;
-	Graph G1 = DorogovtsevMendesGenerator(size).generate();
-	Graph G(G1.upperNodeIdBound(), false, false);
-	G1.forEdges([&](node u, node v) {
-		G.addEdge(u, v);
-		G.addEdge(v, u);
-	});
-	HarmonicCloseness cc(G1, false);
-	cc.run();
-	TopHarmonicCloseness topcc(G, k);
-	topcc.run();
-	const edgeweight tol = 1e-7;
-	for (count i = 0; i < k; i++) {
-		EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
-	}
-	TopHarmonicCloseness topcc2(G, k);
-	topcc2.run();
-	for (count i = 0; i < k; i++) {
-		EXPECT_NEAR(cc.ranking()[i].second, topcc2.topkScoresList()[i], tol);
-	}
+    count size = 400;
+    count k = 10;
+    Graph G1 = DorogovtsevMendesGenerator(size).generate();
+    Graph G(G1.upperNodeIdBound(), false, false);
+    G1.forEdges([&](node u, node v) {
+        G.addEdge(u, v);
+        G.addEdge(v, u);
+    });
+    HarmonicCloseness cc(G1, false);
+    cc.run();
+    TopHarmonicCloseness topcc(G, k);
+    topcc.run();
+    const edgeweight tol = 1e-7;
+    for (count i = 0; i < k; i++) {
+        EXPECT_NEAR(cc.ranking()[i].second, topcc.topkScoresList()[i], tol);
+    }
+    TopHarmonicCloseness topcc2(G, k);
+    topcc2.run();
+    for (count i = 0; i < k; i++) {
+        EXPECT_NEAR(cc.ranking()[i].second, topcc2.topkScoresList()[i], tol);
+    }
 }
 
 TEST_F(CentralityGTest, testLaplacianCentrality) {
-	// The graph structure and reference values for the scores are taken from
-	// Qi et al., Laplacian centrality: A new centrality measure for weighted
-	// networks.
-	//
-	// See
-	// https://math.wvu.edu/~cqzhang/Publication-files/my-paper/INS-2012-Laplacian-W.pdf.
-	Graph G(6, true);
+    // The graph structure and reference values for the scores are taken from
+    // Qi et al., Laplacian centrality: A new centrality measure for weighted
+    // networks.
+    //
+    // See
+    // https://math.wvu.edu/~cqzhang/Publication-files/my-paper/INS-2012-Laplacian-W.pdf.
+    Graph G(6, true);
 
-	G.addEdge(0, 1, 4);
-	G.addEdge(0, 2, 2);
-	G.addEdge(1, 2, 1);
-	G.addEdge(1, 3, 2);
-	G.addEdge(1, 4, 2);
-	G.addEdge(4, 5, 1);
+    G.addEdge(0, 1, 4);
+    G.addEdge(0, 2, 2);
+    G.addEdge(1, 2, 1);
+    G.addEdge(1, 3, 2);
+    G.addEdge(1, 4, 2);
+    G.addEdge(4, 5, 1);
 
-	LaplacianCentrality lc(G);
-	lc.run();
-	std::vector<double> scores = lc.scores();
+    LaplacianCentrality lc(G);
+    lc.run();
+    std::vector<double> scores = lc.scores();
 
-	EXPECT_EQ(140, scores[0]);
-	EXPECT_EQ(180, scores[1]);
-	EXPECT_EQ(56, scores[2]);
-	EXPECT_EQ(44, scores[3]);
-	EXPECT_EQ(52, scores[4]);
-	EXPECT_EQ(8, scores[5]);
+    EXPECT_EQ(140, scores[0]);
+    EXPECT_EQ(180, scores[1]);
+    EXPECT_EQ(56, scores[2]);
+    EXPECT_EQ(44, scores[3]);
+    EXPECT_EQ(52, scores[4]);
+    EXPECT_EQ(8, scores[5]);
 }
 
 TEST_F(CentralityGTest, testLaplacianCentralityNormalized) {
-	Graph G(6, true);
+    Graph G(6, true);
 
-	G.addEdge(0, 1, 4);
-	G.addEdge(0, 2, 2);
-	G.addEdge(1, 2, 1);
-	G.addEdge(1, 3, 2);
-	G.addEdge(1, 4, 2);
-	G.addEdge(4, 5, 1);
+    G.addEdge(0, 1, 4);
+    G.addEdge(0, 2, 2);
+    G.addEdge(1, 2, 1);
+    G.addEdge(1, 3, 2);
+    G.addEdge(1, 4, 2);
+    G.addEdge(4, 5, 1);
 
-	LaplacianCentrality lc(G, true);
-	lc.run();
-	std::vector<double> scores = lc.scores();
+    LaplacianCentrality lc(G, true);
+    lc.run();
+    std::vector<double> scores = lc.scores();
 
-	EXPECT_EQ(0.70, scores[0]);
-	EXPECT_EQ(0.90, scores[1]);
-	EXPECT_EQ(0.28, scores[2]);
-	EXPECT_EQ(0.22, scores[3]);
-	EXPECT_EQ(0.26, scores[4]);
-	EXPECT_EQ(0.04, scores[5]);
+    EXPECT_EQ(0.70, scores[0]);
+    EXPECT_EQ(0.90, scores[1]);
+    EXPECT_EQ(0.28, scores[2]);
+    EXPECT_EQ(0.22, scores[3]);
+    EXPECT_EQ(0.26, scores[4]);
+    EXPECT_EQ(0.04, scores[5]);
 }
 
 TEST_F(CentralityGTest, testLaplacianCentralityUnweighted) {
-	Graph G(6);
+    Graph G(6);
 
-	G.addEdge(0, 1);
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(1, 3);
-	G.addEdge(1, 4);
-	G.addEdge(4, 5);
+    G.addEdge(0, 1);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(1, 3);
+    G.addEdge(1, 4);
+    G.addEdge(4, 5);
 
-	LaplacianCentrality lc(G);
-	lc.run();
-	std::vector<double> scores = lc.scores();
+    LaplacianCentrality lc(G);
+    lc.run();
+    std::vector<double> scores = lc.scores();
 
-	EXPECT_EQ(18, scores[0]);
-	EXPECT_EQ(34, scores[1]);
-	EXPECT_EQ(18, scores[2]);
-	EXPECT_EQ(10, scores[3]);
-	EXPECT_EQ(16, scores[4]);
-	EXPECT_EQ(6, scores[5]);
+    EXPECT_EQ(18, scores[0]);
+    EXPECT_EQ(34, scores[1]);
+    EXPECT_EQ(18, scores[2]);
+    EXPECT_EQ(10, scores[3]);
+    EXPECT_EQ(16, scores[4]);
+    EXPECT_EQ(6, scores[5]);
 }
 
 TEST_F(CentralityGTest, testGroupDegreeUndirected) {
-	Aux::Random::setSeed(42, false);
-	count nodes = 12;
-	Graph g = ErdosRenyiGenerator(nodes, 0.3, false).generate();
-	count k = 5;
+    Aux::Random::setSeed(42, false);
+    count nodes = 12;
+    Graph g = ErdosRenyiGenerator(nodes, 0.3, false).generate();
+    count k = 5;
 
-	GroupDegree gd(g, k, false);
-	gd.run();
-	count score = gd.getScore();
-	GroupDegree gdIncludeGroup(g, k, true);
-	gdIncludeGroup.run();
-	count scorePlusGroup = gdIncludeGroup.getScore();
+    GroupDegree gd(g, k, false);
+    gd.run();
+    count score = gd.getScore();
+    GroupDegree gdIncludeGroup(g, k, true);
+    gdIncludeGroup.run();
+    count scorePlusGroup = gdIncludeGroup.getScore();
 
-	std::vector<bool> reference(nodes, false);
-	for (count i = nodes - k; i < nodes; ++i) {
-		reference[i] = true;
-	}
+    std::vector<bool> reference(nodes, false);
+    for (count i = nodes - k; i < nodes; ++i) {
+        reference[i] = true;
+    }
 
-	auto computeGroupDegree = [&](std::vector<bool> curGroup, Graph g) {
-		count result = 0;
-		g.forNodes([&](node u) {
-			if (!curGroup[u]) {
-				bool neighborInGroup = false;
-				g.forNeighborsOf(u, [&](node v) {
-					if (!neighborInGroup && curGroup[v]) {
-						neighborInGroup = true;
-						++result;
-					}
-				});
-			}
-		});
-		return result;
-	};
+    auto computeGroupDegree = [&](std::vector<bool> curGroup, Graph g) {
+        count result = 0;
+        g.forNodes([&](node u) {
+            if (!curGroup[u]) {
+                bool neighborInGroup = false;
+                g.forNeighborsOf(u, [&](node v) {
+                    if (!neighborInGroup && curGroup[v]) {
+                        neighborInGroup = true;
+                        ++result;
+                    }
+                });
+            }
+        });
+        return result;
+    };
 
-	count maxScore = 0;
+    count maxScore = 0;
 
-	do {
-		count curScore = computeGroupDegree(reference, g);
-		if (curScore > maxScore) {
-			maxScore = curScore;
-		}
-	} while (std::next_permutation(reference.begin(), reference.end()));
+    do {
+        count curScore = computeGroupDegree(reference, g);
+        if (curScore > maxScore) {
+            maxScore = curScore;
+        }
+    } while (std::next_permutation(reference.begin(), reference.end()));
 
-	EXPECT_TRUE(score > 0.5 * maxScore);
-	EXPECT_TRUE(scorePlusGroup >
-	            (1.0 - 1.0 / std::exp(1.0) * (double)(maxScore + k)));
-	EXPECT_EQ(score, gd.scoreOfGroup(gd.groupMaxDegree()));
-	EXPECT_EQ(scorePlusGroup,
-	          gdIncludeGroup.scoreOfGroup(gdIncludeGroup.groupMaxDegree()));
+    EXPECT_TRUE(score > 0.5 * maxScore);
+    EXPECT_TRUE(scorePlusGroup >
+                (1.0 - 1.0 / std::exp(1.0) * (double)(maxScore + k)));
+    EXPECT_EQ(score, gd.scoreOfGroup(gd.groupMaxDegree()));
+    EXPECT_EQ(scorePlusGroup,
+              gdIncludeGroup.scoreOfGroup(gdIncludeGroup.groupMaxDegree()));
 }
 
 TEST_F(CentralityGTest, testGroupDegreeDirected) {
-	Aux::Random::setSeed(42, false);
-	count nodes = 12;
-	Graph g = ErdosRenyiGenerator(nodes, 0.3, true, false).generate();
-	count k = 5;
+    Aux::Random::setSeed(42, false);
+    count nodes = 12;
+    Graph g = ErdosRenyiGenerator(nodes, 0.3, true, false).generate();
+    count k = 5;
 
-	GroupDegree gd(g, k, false);
-	gd.run();
+    GroupDegree gd(g, k, false);
+    gd.run();
 
-	count scoreNoGroup = gd.getScore();
-	GroupDegree gdIncludeGroup(g, k, true);
-	gdIncludeGroup.run();
-	count scorePlusGroup = gdIncludeGroup.getScore();
+    count scoreNoGroup = gd.getScore();
+    GroupDegree gdIncludeGroup(g, k, true);
+    gdIncludeGroup.run();
+    count scorePlusGroup = gdIncludeGroup.getScore();
 
-	std::vector<bool> reference(nodes, false);
-	for (count i = nodes - k; i < nodes; ++i) {
-		reference[i] = true;
-	}
+    std::vector<bool> reference(nodes, false);
+    for (count i = nodes - k; i < nodes; ++i) {
+        reference[i] = true;
+    }
 
-	auto computeGroupDegree = [&](std::vector<bool> curGroup, Graph g) {
-		count result = 0;
-		g.forNodes([&](node u) {
-			if (!curGroup[u]) {
-				bool neighborInGroup = false;
-				g.forInNeighborsOf(u, [&](node v) {
-					if (!neighborInGroup && curGroup[v]) {
-						neighborInGroup = true;
-						++result;
-					}
-				});
-			}
-		});
-		return result;
-	};
+    auto computeGroupDegree = [&](std::vector<bool> curGroup, Graph g) {
+        count result = 0;
+        g.forNodes([&](node u) {
+            if (!curGroup[u]) {
+                bool neighborInGroup = false;
+                g.forInNeighborsOf(u, [&](node v) {
+                    if (!neighborInGroup && curGroup[v]) {
+                        neighborInGroup = true;
+                        ++result;
+                    }
+                });
+            }
+        });
+        return result;
+    };
 
-	count maxScore = 0;
+    count maxScore = 0;
 
-	do {
-		count curScore = computeGroupDegree(reference, g);
-		if (curScore > maxScore) {
-			maxScore = curScore;
-		}
-	} while (std::next_permutation(reference.begin(), reference.end()));
+    do {
+        count curScore = computeGroupDegree(reference, g);
+        if (curScore > maxScore) {
+            maxScore = curScore;
+        }
+    } while (std::next_permutation(reference.begin(), reference.end()));
 
-	EXPECT_TRUE(scoreNoGroup > 0.5 * maxScore);
-	EXPECT_TRUE(scorePlusGroup >
-	            (1.0 - 1.0 / std::exp(1.0)) * (double)(maxScore + k));
-	EXPECT_EQ(scoreNoGroup, gd.scoreOfGroup(gd.groupMaxDegree()));
-	EXPECT_EQ(scorePlusGroup,
-	          gdIncludeGroup.scoreOfGroup(gdIncludeGroup.groupMaxDegree()));
+    EXPECT_TRUE(scoreNoGroup > 0.5 * maxScore);
+    EXPECT_TRUE(scorePlusGroup >
+                (1.0 - 1.0 / std::exp(1.0)) * (double)(maxScore + k));
+    EXPECT_EQ(scoreNoGroup, gd.scoreOfGroup(gd.groupMaxDegree()));
+    EXPECT_EQ(scorePlusGroup,
+              gdIncludeGroup.scoreOfGroup(gdIncludeGroup.groupMaxDegree()));
 }
 
 TEST_F(CentralityGTest, runTestApproxGroupBetweennessSmallGraph) {
 
-	Aux::Random::setSeed(42, false);
+    Aux::Random::setSeed(42, false);
 
-	Graph g(8, false, false);
+    Graph g(8, false, false);
 
-	g.addEdge(0, 2);
-	g.addEdge(1, 2);
-	g.addEdge(2, 3);
-	g.addEdge(2, 4);
-	g.addEdge(3, 5);
-	g.addEdge(4, 5);
-	g.addEdge(5, 6);
-	g.addEdge(5, 7);
-	g.addEdge(0, 5);
+    g.addEdge(0, 2);
+    g.addEdge(1, 2);
+    g.addEdge(2, 3);
+    g.addEdge(2, 4);
+    g.addEdge(3, 5);
+    g.addEdge(4, 5);
+    g.addEdge(5, 6);
+    g.addEdge(5, 7);
+    g.addEdge(0, 5);
 
-	ApproxGroupBetweenness gb(g, 2, 0.1);
-	gb.run();
+    ApproxGroupBetweenness gb(g, 2, 0.1);
+    gb.run();
 }
 
 TEST_F(CentralityGTest, testGroupCloseness) {
-	Aux::Random::setSeed(42, false);
+    Aux::Random::setSeed(42, false);
 
-	Graph g(8, false, false);
+    Graph g(8, false, false);
 
-	g.addEdge(0, 2);
-	g.addEdge(1, 2);
-	g.addEdge(2, 3);
-	g.addEdge(2, 4);
-	g.addEdge(3, 5);
-	g.addEdge(4, 5);
-	g.addEdge(5, 6);
-	g.addEdge(5, 7);
-	g.addEdge(0, 5);
+    g.addEdge(0, 2);
+    g.addEdge(1, 2);
+    g.addEdge(2, 3);
+    g.addEdge(2, 4);
+    g.addEdge(3, 5);
+    g.addEdge(4, 5);
+    g.addEdge(5, 6);
+    g.addEdge(5, 7);
+    g.addEdge(0, 5);
 
-	count k = 3;
+    count k = 3;
 
-	GroupCloseness gc(g, k);
-	gc.run();
-	auto apx = gc.groupMaxCloseness();
-	std::sort(apx.begin(), apx.end());
-	std::vector<node> solution = {0, 2, 5};
-	for (count i = 0; i < k; ++i) {
-		EXPECT_EQ(apx[i], solution[i]);
-	}
+    GroupCloseness gc(g, k);
+    gc.run();
+    auto apx = gc.groupMaxCloseness();
+    std::sort(apx.begin(), apx.end());
+    std::vector<node> solution = {0, 2, 5};
+    for (count i = 0; i < k; ++i) {
+        EXPECT_EQ(apx[i], solution[i]);
+    }
 
-	EXPECT_NEAR(gc.scoreOfGroup(apx), 1.0, 1e-5);
+    EXPECT_NEAR(gc.scoreOfGroup(apx), 1.0, 1e-5);
 }
 
 /**
@@ -1477,29 +1516,29 @@ TEST_F(CentralityGTest, testGroupCloseness) {
  * test fails.
  */
 TEST_F(CentralityGTest, testKadabraAbsolute) {
-	Aux::Random::setSeed(42, true);
-	const count n = 10;
-	Graph g = ErdosRenyiGenerator(n, 0.1).generate();
+    Aux::Random::setSeed(42, true);
+    const count n = 10;
+    Graph g = ErdosRenyiGenerator(n, 0.1).generate();
 
-	const double delta = 0.1;
-	const double epsilon = 0.01;
-	KadabraBetweenness kadabra(g, epsilon, delta);
-	kadabra.run();
-	auto scores = kadabra.topkScoresList();
-	auto nodes = kadabra.topkNodesList();
+    const double delta = 0.1;
+    const double epsilon = 0.01;
+    KadabraBetweenness kadabra(g, epsilon, delta);
+    kadabra.run();
+    auto scores = kadabra.topkScoresList();
+    auto nodes = kadabra.topkNodesList();
 
-	Betweenness betweenness(g, true);
-	betweenness.run();
-	count maxErrors = (count)std::ceil(delta * (double)n);
+    Betweenness betweenness(g, true);
+    betweenness.run();
+    count maxErrors = (count)std::ceil(delta * (double)n);
 
-	count errors = 0;
-	for (count i = 0; i < n; ++i) {
-		if (std::abs(scores[i] - betweenness.score(nodes[i])) > delta) {
-			++errors;
-		}
-	}
+    count errors = 0;
+    for (count i = 0; i < n; ++i) {
+        if (std::abs(scores[i] - betweenness.score(nodes[i])) > delta) {
+            ++errors;
+        }
+    }
 
-	EXPECT_TRUE(errors <= maxErrors);
+    EXPECT_TRUE(errors <= maxErrors);
 }
 
 /**
@@ -1510,230 +1549,230 @@ TEST_F(CentralityGTest, testKadabraAbsolute) {
  */
 
 TEST_F(CentralityGTest, testKadabraTopK) {
-	Aux::Random::setSeed(42, true);
-	const count n = 10;
-	Graph g = ErdosRenyiGenerator(n, 0.1).generate();
+    Aux::Random::setSeed(42, true);
+    const count n = 10;
+    Graph g = ErdosRenyiGenerator(n, 0.1).generate();
 
-	const double delta = 0.1;
-	const double epsilon = 0.01;
-	const count k = 3;
-	KadabraBetweenness kadabra(g, epsilon, delta, k);
-	kadabra.run();
-	auto kadabraRanking = kadabra.ranking();
+    const double delta = 0.1;
+    const double epsilon = 0.01;
+    const count k = 3;
+    KadabraBetweenness kadabra(g, epsilon, delta, k);
+    kadabra.run();
+    auto kadabraRanking = kadabra.ranking();
 
-	Betweenness betweenness(g, true);
-	betweenness.run();
-	auto betwRanking = betweenness.ranking();
-	bool correctRanking = true;
-	for (count i = 0; i < k; ++i) {
-		if (betwRanking[i].first != kadabraRanking[i].first) {
-			correctRanking = false;
-			int j = static_cast<int>(i) - 1;
-			while (j >= 0 && betwRanking[j].second == betwRanking[i].second) {
-				--j;
-			}
-			++j;
-			while (j < n && betwRanking[j].second == betwRanking[i].second) {
-				if (betwRanking[j].first == kadabraRanking[i].first) {
-					correctRanking = true;
-					break;
-				}
-				++j;
-			}
-		}
-	}
-	EXPECT_TRUE(correctRanking);
+    Betweenness betweenness(g, true);
+    betweenness.run();
+    auto betwRanking = betweenness.ranking();
+    bool correctRanking = true;
+    for (count i = 0; i < k; ++i) {
+        if (betwRanking[i].first != kadabraRanking[i].first) {
+            correctRanking = false;
+            int j = static_cast<int>(i) - 1;
+            while (j >= 0 && betwRanking[j].second == betwRanking[i].second) {
+                --j;
+            }
+            ++j;
+            while (j < n && betwRanking[j].second == betwRanking[i].second) {
+                if (betwRanking[j].first == kadabraRanking[i].first) {
+                    correctRanking = true;
+                    break;
+                }
+                ++j;
+            }
+        }
+    }
+    EXPECT_TRUE(correctRanking);
 }
 
 TEST_F(CentralityGTest, testDynTopHarmonicClosenessUndirected) {
-	Graph G = DorogovtsevMendesGenerator(500).generate();
+    Graph G = DorogovtsevMendesGenerator(500).generate();
 
-	count k = 10;
+    count k = 10;
 
-	DynTopHarmonicCloseness centrality(G, k, false);
-	centrality.run();
+    DynTopHarmonicCloseness centrality(G, k, false);
+    centrality.run();
 
-	HarmonicCloseness reference(G, false);
-	reference.run();
+    HarmonicCloseness reference(G, false);
+    reference.run();
 
-	auto scores = centrality.ranking();
-	auto refScores = reference.ranking();
+    auto scores = centrality.ranking();
+    auto refScores = reference.ranking();
 
-	for (count j = 0; j < k; ++j) {
-		EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-	}
+    for (count j = 0; j < k; ++j) {
+        EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+    }
 
-	count numInsertions = 1;
+    count numInsertions = 1;
 
-	std::vector<GraphEvent> deletions;
-	std::vector<GraphEvent> insertions;
+    std::vector<GraphEvent> deletions;
+    std::vector<GraphEvent> insertions;
 
-	for (count i = 0; i < numInsertions; i++) {
+    for (count i = 0; i < numInsertions; i++) {
 
-		node u = G.upperNodeIdBound();
-		node v = G.upperNodeIdBound();
+        node u = G.upperNodeIdBound();
+        node v = G.upperNodeIdBound();
 
-		do {
-			u = G.randomNode();
-			v = G.randomNode();
-		} while (G.hasEdge(u, v));
+        do {
+            u = G.randomNode();
+            v = G.randomNode();
+        } while (G.hasEdge(u, v));
 
-		GraphEvent edgeAddition(GraphEvent::EDGE_ADDITION, u, v);
-		insertions.insert(insertions.begin(), edgeAddition);
+        GraphEvent edgeAddition(GraphEvent::EDGE_ADDITION, u, v);
+        insertions.insert(insertions.begin(), edgeAddition);
 
-		GraphEvent edgeDeletion(GraphEvent::EDGE_REMOVAL, u, v);
-		deletions.push_back(edgeDeletion);
+        GraphEvent edgeDeletion(GraphEvent::EDGE_REMOVAL, u, v);
+        deletions.push_back(edgeDeletion);
 
-		G.addEdge(u, v);
-	}
+        G.addEdge(u, v);
+    }
 
-	for (auto e : insertions) {
-		G.removeEdge(e.u, e.v);
-	}
+    for (auto e : insertions) {
+        G.removeEdge(e.u, e.v);
+    }
 
-	for (GraphEvent edgeAddition : insertions) {
+    for (GraphEvent edgeAddition : insertions) {
 
-		node u = edgeAddition.u;
-		node v = edgeAddition.v;
+        node u = edgeAddition.u;
+        node v = edgeAddition.v;
 
-		G.addEdge(u, v);
+        G.addEdge(u, v);
 
-		centrality.update(edgeAddition);
-		reference.run();
+        centrality.update(edgeAddition);
+        reference.run();
 
-		scores = centrality.ranking();
-		refScores = reference.ranking();
+        scores = centrality.ranking();
+        refScores = reference.ranking();
 
-		for (count j = 0; j < k; ++j) {
-			EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-		}
-	}
+        for (count j = 0; j < k; ++j) {
+            EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+        }
+    }
 
-	for (GraphEvent edgeDeletion : deletions) {
-		node u = edgeDeletion.u;
-		node v = edgeDeletion.v;
+    for (GraphEvent edgeDeletion : deletions) {
+        node u = edgeDeletion.u;
+        node v = edgeDeletion.v;
 
-		G.removeEdge(u, v);
+        G.removeEdge(u, v);
 
-		centrality.update(edgeDeletion);
-		reference.run();
+        centrality.update(edgeDeletion);
+        reference.run();
 
-		scores = centrality.ranking();
-		refScores = reference.ranking();
+        scores = centrality.ranking();
+        refScores = reference.ranking();
 
-		for (count j = 0; j < k; ++j) {
-			EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-		}
-	}
+        for (count j = 0; j < k; ++j) {
+            EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+        }
+    }
 
-	for (GraphEvent edgeInsertion : insertions) {
-		G.addEdge(edgeInsertion.u, edgeInsertion.v);
-	}
+    for (GraphEvent edgeInsertion : insertions) {
+        G.addEdge(edgeInsertion.u, edgeInsertion.v);
+    }
 
-	reference.run();
-	centrality.updateBatch(insertions);
+    reference.run();
+    centrality.updateBatch(insertions);
 
-	scores = centrality.ranking();
-	refScores = reference.ranking();
+    scores = centrality.ranking();
+    refScores = reference.ranking();
 
-	for (count j = 0; j < k; ++j) {
-		EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-	}
+    for (count j = 0; j < k; ++j) {
+        EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+    }
 }
 
 TEST_F(CentralityGTest, testDynTopHarmonicClosenessDirected) {
-	Graph G = ErdosRenyiGenerator(300, 0.1, true).generate();
+    Graph G = ErdosRenyiGenerator(300, 0.1, true).generate();
 
-	count k = 10;
+    count k = 10;
 
-	DynTopHarmonicCloseness centrality(G, k, false);
-	centrality.run();
+    DynTopHarmonicCloseness centrality(G, k, false);
+    centrality.run();
 
-	HarmonicCloseness reference(G, false);
-	reference.run();
+    HarmonicCloseness reference(G, false);
+    reference.run();
 
-	auto scores = centrality.ranking();
-	auto refScores = reference.ranking();
-	for (count j = 0; j < k; ++j) {
-		EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-	}
+    auto scores = centrality.ranking();
+    auto refScores = reference.ranking();
+    for (count j = 0; j < k; ++j) {
+        EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+    }
 
-	count numInsertions = 1;
+    count numInsertions = 1;
 
-	std::vector<GraphEvent> deletions;
-	std::vector<GraphEvent> insertions;
+    std::vector<GraphEvent> deletions;
+    std::vector<GraphEvent> insertions;
 
-	for (count i = 0; i < numInsertions; i++) {
+    for (count i = 0; i < numInsertions; i++) {
 
-		node u = G.upperNodeIdBound();
-		node v = G.upperNodeIdBound();
+        node u = G.upperNodeIdBound();
+        node v = G.upperNodeIdBound();
 
-		do {
-			u = G.randomNode();
-			v = G.randomNode();
-		} while (G.hasEdge(u, v));
+        do {
+            u = G.randomNode();
+            v = G.randomNode();
+        } while (G.hasEdge(u, v));
 
-		GraphEvent edgeAddition(GraphEvent::EDGE_ADDITION, u, v);
-		insertions.insert(insertions.begin(), edgeAddition);
+        GraphEvent edgeAddition(GraphEvent::EDGE_ADDITION, u, v);
+        insertions.insert(insertions.begin(), edgeAddition);
 
-		GraphEvent edgeDeletion(GraphEvent::EDGE_REMOVAL, u, v);
-		deletions.push_back(edgeDeletion);
+        GraphEvent edgeDeletion(GraphEvent::EDGE_REMOVAL, u, v);
+        deletions.push_back(edgeDeletion);
 
-		G.addEdge(u, v);
-	}
+        G.addEdge(u, v);
+    }
 
-	for (auto e : insertions) {
-		G.removeEdge(e.u, e.v);
-	}
+    for (auto e : insertions) {
+        G.removeEdge(e.u, e.v);
+    }
 
-	for (GraphEvent edgeAddition : insertions) {
+    for (GraphEvent edgeAddition : insertions) {
 
-		node u = edgeAddition.u;
-		node v = edgeAddition.v;
+        node u = edgeAddition.u;
+        node v = edgeAddition.v;
 
-		G.addEdge(u, v);
+        G.addEdge(u, v);
 
-		centrality.update(edgeAddition);
-		reference.run();
+        centrality.update(edgeAddition);
+        reference.run();
 
-		scores = centrality.ranking();
-		refScores = reference.ranking();
+        scores = centrality.ranking();
+        refScores = reference.ranking();
 
-		for (count j = 0; j < k; ++j) {
-			EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-		}
-	}
+        for (count j = 0; j < k; ++j) {
+            EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+        }
+    }
 
-	for (GraphEvent edgeDeletion : deletions) {
+    for (GraphEvent edgeDeletion : deletions) {
 
-		node u = edgeDeletion.u;
-		node v = edgeDeletion.v;
+        node u = edgeDeletion.u;
+        node v = edgeDeletion.v;
 
-		G.removeEdge(u, v);
+        G.removeEdge(u, v);
 
-		centrality.update(edgeDeletion);
-		reference.run();
+        centrality.update(edgeDeletion);
+        reference.run();
 
-		scores = centrality.ranking();
-		refScores = reference.ranking();
+        scores = centrality.ranking();
+        refScores = reference.ranking();
 
-		for (count j = 0; j < k; ++j) {
-			EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-		}
-	}
+        for (count j = 0; j < k; ++j) {
+            EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+        }
+    }
 
-	for (GraphEvent edgeInsertion : insertions) {
-		G.addEdge(edgeInsertion.u, edgeInsertion.v);
-	}
+    for (GraphEvent edgeInsertion : insertions) {
+        G.addEdge(edgeInsertion.u, edgeInsertion.v);
+    }
 
-	reference.run();
-	centrality.updateBatch(insertions);
+    reference.run();
+    centrality.updateBatch(insertions);
 
-	scores = centrality.ranking();
-	refScores = reference.ranking();
+    scores = centrality.ranking();
+    refScores = reference.ranking();
 
-	for (count j = 0; j < k; ++j) {
-		EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
-	}
+    for (count j = 0; j < k; ++j) {
+        EXPECT_FLOAT_EQ(scores[j].second, refScores[j].second);
+    }
 }
 } /* namespace NetworKit */

--- a/networkit/cpp/distance/BFS.cpp
+++ b/networkit/cpp/distance/BFS.cpp
@@ -5,74 +5,75 @@
  *      Author: Henning
  */
 
-#include <queue>
 #include "../../include/networkit/distance/BFS.hpp"
+#include <queue>
 
 namespace NetworKit {
 
-BFS::BFS(const Graph& G, node source, bool storePaths, bool storeNodesSortedByDistance, node target) : SSSP(G, source, storePaths, storeNodesSortedByDistance, target) {
-}
-
+BFS::BFS(const Graph &G, node source, bool storePaths,
+         bool storeNodesSortedByDistance, node target)
+    : SSSP(G, source, storePaths, storeNodesSortedByDistance, target) {}
 
 void BFS::run() {
-	edgeweight infDist = std::numeric_limits<edgeweight>::max();
-	count z = G.upperNodeIdBound();
-	distances.clear();
-	distances.resize(z, infDist);
+    edgeweight infDist = std::numeric_limits<edgeweight>::max();
+    count z = G.upperNodeIdBound();
+    distances.clear();
+    distances.resize(z, infDist);
 
-	std::vector<bool> visited;
-	visited.resize(z, false);
+    std::vector<bool> visited;
+    visited.resize(z, false);
 
-	if (storePaths) {
-		previous.clear();
-		previous.resize(z);
-		npaths.clear();
-		npaths.resize(z, 0);
-		npaths[source] = 1;
-	}
+    if (storePaths) {
+        previous.clear();
+        previous.resize(z);
+        npaths.clear();
+        npaths.resize(z, 0);
+        npaths[source] = 1;
+    }
 
-	if (storeNodesSortedByDistance) {
-		std::vector<node> empty;
-		std::swap(nodesSortedByDistance, empty);
-	}
+    if (storeNodesSortedByDistance) {
+        std::vector<node> empty;
+        std::swap(nodesSortedByDistance, empty);
+    }
 
-	std::queue<node> q;
-	q.push(source);
-	visited[source] = true;
-	distances[source] = 0;
-	bool breakWhenFound = (target != none);
-	while (! q.empty()) {
-		node u = q.front();
-		q.pop();
+    std::queue<node> q;
+    q.push(source);
+    visited[source] = true;
+    distances[source] = 0;
+    bool breakWhenFound = (target != none);
+    while (!q.empty()) {
+        node u = q.front();
+        q.pop();
 
-		if (storeNodesSortedByDistance) {
-			nodesSortedByDistance.push_back(u);
-		}
-		if (breakWhenFound && target == u) {
-			break;
-		}
+        if (storeNodesSortedByDistance) {
+            nodesSortedByDistance.push_back(u);
+        }
+        if (breakWhenFound && target == u) {
+            break;
+        }
 
-		// TRACE("current node in BFS: " , u);
-//		TRACE(distances);
+        // TRACE("current node in BFS: " , u);
+        //		TRACE(distances);
 
-		// insert untouched neighbors into queue
-		G.forNeighborsOf(u, [&](node v) {
-			// TRACE("scanning neighbor ", v);
+        // insert untouched neighbors into queue
+        G.forNeighborsOf(u, [&](node v) {
+            // TRACE("scanning neighbor ", v);
 
-			if (!visited[v]) {
-				q.push(v);
-				visited[v] = true;
-				distances[v] = distances[u] + 1;
-				if (storePaths) {
-					previous[v] = {u};
-					npaths[v] = npaths[u];
-				}
-			} else if (storePaths && (distances[v] == distances[u] + 1)) {
-				previous[v].push_back(u); 	// additional predecessor
-				npaths[v] += npaths[u]; 	// all the shortest paths to u are also shortest paths to v now
-			}
-		});
-	}
+            if (!visited[v]) {
+                q.push(v);
+                visited[v] = true;
+                distances[v] = distances[u] + 1;
+                if (storePaths) {
+                    previous[v] = {u};
+                    npaths[v] = npaths[u];
+                }
+            } else if (storePaths && (distances[v] == distances[u] + 1)) {
+                previous[v].push_back(u); // additional predecessor
+                npaths[v] += npaths[u]; // all the shortest paths to u are also
+                                        // shortest paths to v now
+            }
+        });
+    }
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/distance/Dijkstra.cpp
+++ b/networkit/cpp/distance/Dijkstra.cpp
@@ -12,69 +12,69 @@
 namespace NetworKit {
 
 Dijkstra::Dijkstra(const Graph &G, node source, bool storePaths,
-									 bool storeNodesSortedByDistance, node target)
-		: SSSP(G, source, storePaths, storeNodesSortedByDistance, target) {}
+                   bool storeNodesSortedByDistance, node target)
+    : SSSP(G, source, storePaths, storeNodesSortedByDistance, target) {}
 
 void Dijkstra::run() {
 
-	TRACE("initializing Dijkstra data structures");
-	// init distances
-	edgeweight infDist = std::numeric_limits<edgeweight>::max();
-	distances.clear();
-	distances.resize(G.upperNodeIdBound(), infDist);
-	if (storePaths) {
-		previous.clear();
-		previous.resize(G.upperNodeIdBound());
-		npaths.clear();
-		npaths.resize(G.upperNodeIdBound(), 0);
-		npaths[source] = 1;
-	}
+    TRACE("initializing Dijkstra data structures");
+    // init distances
+    edgeweight infDist = std::numeric_limits<edgeweight>::max();
+    distances.clear();
+    distances.resize(G.upperNodeIdBound(), infDist);
+    if (storePaths) {
+        previous.clear();
+        previous.resize(G.upperNodeIdBound());
+        npaths.clear();
+        npaths.resize(G.upperNodeIdBound(), 0);
+        npaths[source] = 1;
+    }
 
-	if (storeNodesSortedByDistance) {
-		std::vector<node> empty;
-		std::swap(nodesSortedByDistance, empty);
-	}
+    if (storeNodesSortedByDistance) {
+        std::vector<node> empty;
+        std::swap(nodesSortedByDistance, empty);
+    }
 
-	// priority queue with distance-node pairs
-	distances[source] = 0;
-	Aux::PrioQueue<edgeweight, node> pq(distances);
+    // priority queue with distance-node pairs
+    distances[source] = 0;
+    Aux::PrioQueue<edgeweight, node> pq(distances);
 
-	auto relax([&](node u, node v, edgeweight w) {
-		if (distances[v] > distances[u] + w) {
-			distances[v] = distances[u] + w;
-			if (storePaths) {
-				previous[v] = {u}; // new predecessor on shortest path
-				npaths[v] = npaths[u];
-			}
-			TRACE("Decreasing key of ", v);
-			TRACE("pq size: ", pq.size());
-			pq.changeKey(distances[v], v);
-			TRACE("pq size: ", pq.size());
-		} else if (storePaths && (distances[v] == distances[u] + w)) {
-			previous[v].push_back(u); // additional predecessor
-			npaths[v] += npaths[u];   // all the shortest paths to u are
-																// also shortest paths to v now
-		}
-	});
+    auto relax([&](node u, node v, edgeweight w) {
+        if (distances[v] > distances[u] + w) {
+            distances[v] = distances[u] + w;
+            if (storePaths) {
+                previous[v] = {u}; // new predecessor on shortest path
+                npaths[v] = npaths[u];
+            }
+            TRACE("Decreasing key of ", v);
+            TRACE("pq size: ", pq.size());
+            pq.changeKey(distances[v], v);
+            TRACE("pq size: ", pq.size());
+        } else if (storePaths && (distances[v] == distances[u] + w)) {
+            previous[v].push_back(u); // additional predecessor
+            npaths[v] += npaths[u];   // all the shortest paths to u are
+                                      // also shortest paths to v now
+        }
+    });
 
-	bool breakWhenFound = (target != none);
-	TRACE("traversing graph");
-	while (pq.size() > 0) {
-		TRACE("pq size: ", pq.size());
-		node current = pq.extractMin().second;
-		TRACE("current node in Dijkstra: ", current);
-		TRACE("pq size: ", pq.size());
-		if ((breakWhenFound && target == current) ||
-				distances[current] == infDist) {
-			break;
-		}
+    bool breakWhenFound = (target != none);
+    TRACE("traversing graph");
+    while (pq.size() > 0) {
+        TRACE("pq size: ", pq.size());
+        node current = pq.extractMin().second;
+        TRACE("current node in Dijkstra: ", current);
+        TRACE("pq size: ", pq.size());
+        if ((breakWhenFound && target == current) ||
+            distances[current] == infDist) {
+            break;
+        }
 
-		if (storeNodesSortedByDistance) {
-			nodesSortedByDistance.push_back(current);
-		}
+        if (storeNodesSortedByDistance) {
+            nodesSortedByDistance.push_back(current);
+        }
 
-		G.forEdgesOf(current, relax);
-	}
+        G.forEdgesOf(current, relax);
+    }
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/distance/Dijkstra.cpp
+++ b/networkit/cpp/distance/Dijkstra.cpp
@@ -13,15 +13,27 @@ namespace NetworKit {
 
 Dijkstra::Dijkstra(const Graph &G, node source, bool storePaths,
                    bool storeNodesSortedByDistance, node target)
-    : SSSP(G, source, storePaths, storeNodesSortedByDistance, target) {}
+    : SSSP(G, source, storePaths, storeNodesSortedByDistance, target),
+      heap(Compare(distances)) {}
 
 void Dijkstra::run() {
 
     TRACE("initializing Dijkstra data structures");
     // init distances
-    edgeweight infDist = std::numeric_limits<edgeweight>::max();
-    distances.clear();
-    distances.resize(G.upperNodeIdBound(), infDist);
+    if (distances.size() < G.upperNodeIdBound()) {
+        distances.resize(G.upperNodeIdBound(),
+                         std::numeric_limits<double>::max());
+        visited.resize(G.upperNodeIdBound(), ts);
+    }
+
+    sumDist = 0.;
+    reachedNodes = 1;
+
+    if (ts++ == 255) {
+        ts = 1;
+        std::fill(visited.begin(), visited.end(), 0);
+    }
+
     if (storePaths) {
         previous.clear();
         previous.resize(G.upperNodeIdBound());
@@ -31,50 +43,56 @@ void Dijkstra::run() {
     }
 
     if (storeNodesSortedByDistance) {
-        std::vector<node> empty;
-        std::swap(nodesSortedByDistance, empty);
+        nodesSortedByDistance.clear();
+        nodesSortedByDistance.reserve(G.upperNodeIdBound());
     }
 
     // priority queue with distance-node pairs
-    distances[source] = 0;
-    Aux::PrioQueue<edgeweight, node> pq(distances);
+    distances[source] = 0.;
+    visited[source] = ts;
+    heap.push(source);
 
-    auto relax([&](node u, node v, edgeweight w) {
-        if (distances[v] > distances[u] + w) {
-            distances[v] = distances[u] + w;
-            if (storePaths) {
-                previous[v] = {u}; // new predecessor on shortest path
-                npaths[v] = npaths[u];
-            }
-            TRACE("Decreasing key of ", v);
-            TRACE("pq size: ", pq.size());
-            pq.changeKey(distances[v], v);
-            TRACE("pq size: ", pq.size());
-        } else if (storePaths && (distances[v] == distances[u] + w)) {
-            previous[v].push_back(u); // additional predecessor
-            npaths[v] += npaths[u];   // all the shortest paths to u are
-                                      // also shortest paths to v now
+    auto initPath = [&](node u, node v) {
+        if (storePaths) {
+            previous[v] = {u};
+            npaths[v] = npaths[u];
         }
-    });
-
+    };
     bool breakWhenFound = (target != none);
     TRACE("traversing graph");
-    while (pq.size() > 0) {
-        TRACE("pq size: ", pq.size());
-        node current = pq.extractMin().second;
-        TRACE("current node in Dijkstra: ", current);
-        TRACE("pq size: ", pq.size());
-        if ((breakWhenFound && target == current) ||
-            distances[current] == infDist) {
+    do {
+        TRACE("pq size: ", heap.size());
+        node u = heap.extract_top();
+        sumDist += distances[u];
+        TRACE("current node in Dijkstra: ", u);
+        TRACE("pq size: ", heap.size());
+        if ((breakWhenFound && target == u) || visited[u] != ts)
             break;
-        }
 
-        if (storeNodesSortedByDistance) {
-            nodesSortedByDistance.push_back(current);
-        }
+        if (storeNodesSortedByDistance)
+            nodesSortedByDistance.push_back(u);
 
-        G.forEdgesOf(current, relax);
-    }
+        G.forNeighborsOf(u, [&](node v, edgeweight w) {
+            double newDist = distances[u] + w;
+            if (ts != visited[v]) {
+                visited[v] = ts;
+                distances[v] = newDist;
+                heap.push(v);
+                ++reachedNodes;
+                if (storePaths)
+                    initPath(u, v);
+            } else if (distances[v] > newDist) {
+                if (storePaths)
+                    initPath(u, v);
+                distances[v] = newDist;
+                heap.update(v);
+            } else if (storePaths && distances[v] == newDist) {
+                previous[v].push_back(u);
+                npaths[v] += npaths[u];
+            }
+        });
+    } while (!heap.empty());
+
+    hasRun = true;
 }
-
-} /* namespace NetworKit */
+} // namespace NetworKit

--- a/networkit/cpp/distance/DynAPSP.cpp
+++ b/networkit/cpp/distance/DynAPSP.cpp
@@ -43,21 +43,21 @@ void DynAPSP::run() {
 }
 
 std::vector<node> DynAPSP::getPath(node u, node v) {
-	std::vector<node> path = {};
-	if (distances[u][v] != infDist) {
-		node current = v;
-		while (current != u) {
-			path.push_back(current);
-			G.forInEdgesOf(current, [&](node z, edgeweight w){
-				if (distances[u][current] == distances[u][z] + w) {
-					current = z;
-				}
-			});
-		}
-		path.push_back(u);
-		std::reverse(path.begin(), path.end());
-	}
-	return path;
+    std::vector<node> path = {};
+    if (distances[u][v] < std::numeric_limits<edgeweight>::max()) {
+        node current = v;
+        while (current != u) {
+            path.push_back(current);
+            G.forInEdgesOf(current, [&](node z, edgeweight w) {
+                if (distances[u][current] == distances[u][z] + w) {
+                    current = z;
+                }
+            });
+        }
+        path.push_back(u);
+        std::reverse(path.begin(), path.end());
+    }
+    return path;
 }
 
 

--- a/networkit/cpp/distance/SSSP.cpp
+++ b/networkit/cpp/distance/SSSP.cpp
@@ -1,130 +1,126 @@
 /*
-* SSSP.cpp
-*
-*  Created on: 15.04.2014
-*      Author: cls
-*/
+ * SSSP.cpp
+ *
+ *  Created on: 15.04.2014
+ *      Author: cls
+ */
 
 #include "../../include/networkit/distance/SSSP.hpp"
 #include "../../include/networkit/auxiliary/Log.hpp"
 
 namespace NetworKit {
 
-	SSSP::SSSP (
-		const Graph& G,
-		node source,
-		bool storePaths,
-		bool storeNodesSortedByDistance,
-		node target
-	) :
-	Algorithm(),
-	G(G),
-	source(source),
-	target(target),
-	storePaths(storePaths),
-	storeNodesSortedByDistance(storeNodesSortedByDistance) {}
+SSSP::SSSP(const Graph &G, node source, bool storePaths,
+           bool storeNodesSortedByDistance, node target)
+    : Algorithm(), G(G), source(source), target(target), storePaths(storePaths),
+      storeNodesSortedByDistance(storeNodesSortedByDistance) {}
 
-	std::vector<edgeweight> SSSP::getDistances(bool moveOut) {
-		return (moveOut)?std::move(distances):distances;
-	}
+std::vector<edgeweight> SSSP::getDistances(bool moveOut) {
+    return (moveOut) ? std::move(distances) : distances;
+}
 
-	std::vector<node> SSSP::getPath(node t, bool forward) const {
-		if (! storePaths) {
-			throw std::runtime_error("paths have not been stored");
-		}
-		std::vector<node> path;
-		if (previous[t].empty()) { // t is not reachable from source
-			WARN("there is no path from ", source, " to ", t);
-			return path;
-		}
-		node v = t;
-		while (v != source) {
-			path.push_back(v);
-			v = previous[v].front();
-		}
-		path.push_back(source);
+std::vector<node> SSSP::getPath(node t, bool forward) const {
+    if (!storePaths) {
+        throw std::runtime_error("paths have not been stored");
+    }
+    std::vector<node> path;
+    if (previous[t].empty()) { // t is not reachable from source
+        WARN("there is no path from ", source, " to ", t);
+        return path;
+    }
+    node v = t;
+    while (v != source) {
+        path.push_back(v);
+        v = previous[v].front();
+    }
+    path.push_back(source);
 
-		if (forward) {
-			std::reverse(path.begin(), path.end());
-		}
-		return path;
-	}
+    if (forward) {
+        std::reverse(path.begin(), path.end());
+    }
+    return path;
+}
 
-	std::set<std::vector<node>> SSSP::getPaths(node t, bool forward) const {
+std::set<std::vector<node>> SSSP::getPaths(node t, bool forward) const {
 
-		std::set<std::vector<node>> paths;
-		if (previous[t].empty()) { // t is not reachable from source
-			WARN("there is no path from ", source, " to ", t);
-			return paths;
-		}
+    std::set<std::vector<node>> paths;
+    if (previous[t].empty()) { // t is not reachable from source
+        WARN("there is no path from ", source, " to ", t);
+        return paths;
+    }
 
-		std::vector<node> targetPredecessors = previous[t];
+    std::vector<node> targetPredecessors = previous[t];
 
-		#pragma omp parallel for schedule(dynamic)
-		for (omp_index i = 0; i < static_cast<omp_index>(targetPredecessors.size()); ++i) {
+#pragma omp parallel for schedule(dynamic)
+    for (omp_index i = 0; i < static_cast<omp_index>(targetPredecessors.size());
+         ++i) {
 
-			std::stack<std::vector<node>> stack;
-			std::vector<std::vector<node>> currPaths;
+        std::stack<std::vector<node>> stack;
+        std::vector<std::vector<node>> currPaths;
 
-			node pred = targetPredecessors[i];
-			if (pred == source) {
-				currPaths.push_back({t, pred});
-			}
-			else {
-				stack.push({t, pred});
-			}
+        node pred = targetPredecessors[i];
+        if (pred == source) {
+            currPaths.push_back({t, pred});
+        } else {
+            stack.push({t, pred});
+        }
 
-			while (!stack.empty()) {
+        while (!stack.empty()) {
 
-				node topPathLastNode = stack.top().back();
+            node topPathLastNode = stack.top().back();
 
-				if (topPathLastNode == source) {
-					currPaths.push_back(stack.top());
-					stack.pop();
-					continue;
-				}
+            if (topPathLastNode == source) {
+                currPaths.push_back(stack.top());
+                stack.pop();
+                continue;
+            }
 
-				std::vector<node> topPath = stack.top();
-				stack.pop();
+            std::vector<node> topPath = stack.top();
+            stack.pop();
 
-				std::vector<node> currPredecessors = previous[topPath.back()];
+            std::vector<node> currPredecessors = previous[topPath.back()];
 
-				for (node currPredecessor : currPredecessors) {
-					std::vector<node> suffix(topPath);
-					suffix.push_back(currPredecessor);
-					stack.push(suffix);
-				}
-			}
+            for (node currPredecessor : currPredecessors) {
+                std::vector<node> suffix(topPath);
+                suffix.push_back(currPredecessor);
+                stack.push(suffix);
+            }
+        }
 
-			#pragma omp critical
-			paths.insert(currPaths.begin(), currPaths.end());
-		}
+#pragma omp critical
+        paths.insert(currPaths.begin(), currPaths.end());
+    }
 
-		if (forward) {
-			std::set<std::vector<node>> reversedPaths;
-			for (std::vector<node> path : paths) {
-				std::reverse(std::begin(path), std::end(path));
-				reversedPaths.insert(path);
-			}
-			paths = reversedPaths;
-		}
+    if (forward) {
+        std::set<std::vector<node>> reversedPaths;
+        for (std::vector<node> path : paths) {
+            std::reverse(std::begin(path), std::end(path));
+            reversedPaths.insert(path);
+        }
+        paths = reversedPaths;
+    }
 
-		return paths;
-	}
+    return paths;
+}
 
-	std::vector<node> SSSP::getNodesSortedByDistance(bool moveOut) {
-		if (!storeNodesSortedByDistance) {
-			throw std::runtime_error("Nodes sorted by distance have not been stored. Set storeNodesSortedByDistance in the constructor to true to enable this behaviour.");
-		} else if (nodesSortedByDistance.empty()) {
-			throw std::runtime_error("The container has already been moved or run() has not been called yet. Please call run() first.");
-		}
-		if (moveOut) {
-			std::vector<node> tmp;
-			std::swap(nodesSortedByDistance, tmp);
-			return tmp;
-		}
+std::vector<node> SSSP::getNodesSortedByDistance(bool moveOut) {
+    if (!storeNodesSortedByDistance) {
+        throw std::runtime_error(
+            "Nodes sorted by distance have not been stored. Set "
+            "storeNodesSortedByDistance in the constructor to true to enable "
+            "this behaviour.");
+    } else if (nodesSortedByDistance.empty()) {
+        throw std::runtime_error(
+            "The container has already been moved or run() has not been called "
+            "yet. Please call run() first.");
+    }
+    if (moveOut) {
+        std::vector<node> tmp;
+        std::swap(nodesSortedByDistance, tmp);
+        return tmp;
+    }
 
-		return nodesSortedByDistance;
-	}
+    return nodesSortedByDistance;
+}
 
 } /* namespace NetworKit */

--- a/networkit/cpp/distance/SSSP.cpp
+++ b/networkit/cpp/distance/SSSP.cpp
@@ -12,7 +12,8 @@ namespace NetworKit {
 
 SSSP::SSSP(const Graph &G, node source, bool storePaths,
            bool storeNodesSortedByDistance, node target)
-    : Algorithm(), G(G), source(source), target(target), storePaths(storePaths),
+    : Algorithm(), G(G), source(source), target(target), ts(0),
+      storePaths(storePaths),
       storeNodesSortedByDistance(storeNodesSortedByDistance) {}
 
 std::vector<edgeweight> SSSP::getDistances(bool moveOut) {

--- a/networkit/cpp/distance/test/SSSPGTest.cpp
+++ b/networkit/cpp/distance/test/SSSPGTest.cpp
@@ -21,34 +21,33 @@ namespace NetworKit {
 class SSSPGTest: public testing::Test{};
 
 TEST_F(SSSPGTest, testDijkstra) {
-/* Graph:
-         ______
-		/      \
-	   0    3   6
-		\  / \ /
-		 2    5
-		/  \ / \
-	   1    4   7
-*/
-	int n = 8;
-	Graph G(n, true);
+    /* Graph:
+             ______
+        /      \
+         0    3   6
+        \  / \ /
+         2    5
+        /  \ / \
+         1    4   7
+    */
+    int n = 8;
+    Graph G(n, true);
 
-	G.addEdge(0, 2);
-	G.addEdge(1, 2);
-	G.addEdge(2, 3);
-	G.addEdge(2, 4);
-	G.addEdge(3, 5);
-	G.addEdge(4, 5);
-	G.addEdge(5, 6);
-	G.addEdge(5, 7);
-	G.addEdge(0, 6);
+    G.addEdge(0, 2);
+    G.addEdge(1, 2);
+    G.addEdge(2, 3);
+    G.addEdge(2, 4);
+    G.addEdge(3, 5);
+    G.addEdge(4, 5);
+    G.addEdge(5, 6);
+    G.addEdge(5, 7);
+    G.addEdge(0, 6);
 
-
-	Dijkstra sssp(G, 5, true, true);
-	EXPECT_NO_THROW(sssp.run());
-	std::vector<node> stack = sssp.getNodesSortedByDistance();
-	std::vector<node> result {5,3,4,6,7,0,2,1};
-	ASSERT_EQ(stack,result);
+    Dijkstra sssp(G, 5, true, true);
+    EXPECT_NO_THROW(sssp.run());
+    std::vector<node> stack = sssp.getNodesSortedByDistance();
+    for (count i = 0; i < stack.size() - 1; ++i)
+        EXPECT_LE(sssp.distance(stack[i]), sssp.distance(stack[i + 1]));
 }
 
 TEST_F(SSSPGTest, testShortestPaths) {

--- a/networkit/cpp/viz/PivotMDS.cpp
+++ b/networkit/cpp/viz/PivotMDS.cpp
@@ -17,127 +17,132 @@
 
 namespace NetworKit {
 
-PivotMDS::PivotMDS(const Graph& graph, count dim, count numPivots) : GraphLayoutAlgorithm(graph, dim), dim(dim), numPivots(numPivots) {
-}
+PivotMDS::PivotMDS(const Graph &graph, count dim, count numPivots)
+    : GraphLayoutAlgorithm(graph, dim), dim(dim), numPivots(numPivots) {}
 
 void PivotMDS::run() {
-	count n = G.numberOfNodes();
-	std::vector<node> pivots = computePivots();
+    count n = G.numberOfNodes();
+    std::vector<node> pivots = computePivots();
 
-	std::vector<Triplet> triplets;
-	for (index j = 0; j < numPivots; ++j) { // compute distances from pivots to other nodes
-		Aux::PrioQueue<edgeweight, node> PQ(n);
-		std::vector<edgeweight> dist(n, none);
+    std::vector<Triplet> triplets;
+    for (index j = 0; j < numPivots;
+         ++j) { // compute distances from pivots to other nodes
+        Aux::PrioQueue<edgeweight, node> PQ(n);
+        std::vector<edgeweight> dist(n, none);
 
-		dist[pivots[j]] = 0;
-		PQ.insert(0, pivots[j]);
-		while (PQ.size() > 0) {
-			node v = PQ.extractMin().second;
-			triplets.push_back({v, j, dist[v]});
-			G.forNeighborsOf(v, [&](node w, edgeweight weight) {
-				if (dist[v] + weight < dist[w]) {
-					dist[w] = dist[v] + weight;
-					PQ.changeKey(dist[w], w);
-				}
-			});
-		}
-	}
+        dist[pivots[j]] = 0;
+        PQ.insert(0, pivots[j]);
+        while (PQ.size() > 0) {
+            node v = PQ.extractMin().second;
+            triplets.push_back({v, j, dist[v]});
+            G.forNeighborsOf(v, [&](node w, edgeweight weight) {
+                if (dist[v] + weight < dist[w]) {
+                    dist[w] = dist[v] + weight;
+                    PQ.changeKey(dist[w], w);
+                }
+            });
+        }
+    }
 
-	// double center the squared distance matrix
-	std::vector<double> rowMean(n, 0.0);
-	std::vector<double> colMean(numPivots, 0.0);
+    // double center the squared distance matrix
+    std::vector<double> rowMean(n, 0.0);
+    std::vector<double> colMean(numPivots, 0.0);
 
-	for (Triplet& triplet : triplets) {
-		rowMean[triplet.row] += triplet.value / (double) numPivots;
-		colMean[triplet.column] += triplet.value / (double) n;
-	}
+    for (Triplet &triplet : triplets) {
+        rowMean[triplet.row] += triplet.value / (double)numPivots;
+        colMean[triplet.column] += triplet.value / (double)n;
+    }
 
-	double grandMean = 0.0;
-	double rowDivisor = 1.0 / (2.0 * (double) n);
-	double colDivisor = 1.0 / (2.0 * (double) numPivots);
-	for (index i = 0; i < n; ++i) {
-		grandMean += rowMean[i] * rowDivisor;
-	}
+    double grandMean = 0.0;
+    double rowDivisor = 1.0 / (2.0 * (double)n);
+    double colDivisor = 1.0 / (2.0 * (double)numPivots);
+    for (index i = 0; i < n; ++i) {
+        grandMean += rowMean[i] * rowDivisor;
+    }
 
-	for (index j = 0; j < numPivots; ++j) {
-		grandMean += colMean[j] * colDivisor;
-	}
+    for (index j = 0; j < numPivots; ++j) {
+        grandMean += colMean[j] * colDivisor;
+    }
 
-	for (Triplet& triplet : triplets) {
-		triplet.value = triplet.value - rowMean[triplet.row] - colMean[triplet.column] + grandMean;
-	}
+    for (Triplet &triplet : triplets) {
+        triplet.value = triplet.value - rowMean[triplet.row] -
+                        colMean[triplet.column] + grandMean;
+    }
 
-	CSRMatrix C(n, numPivots, triplets);
+    CSRMatrix C(n, numPivots, triplets);
 
-	// compute C^T * C
-	CSRMatrix CC = CSRMatrix::mTmMultiply(C, C);
-	CC.sort();
+    // compute C^T * C
+    CSRMatrix CC = CSRMatrix::mTmMultiply(C, C);
+    CC.sort();
 
-	// power iterate to get the first dim largest eigenvectors
-	for (index d = 0; d < dim; ++d) {
-		Vector eigenvector;
-		double eigenvalue;
-		powerMethod(CC, numPivots, eigenvector, eigenvalue);
+    // power iterate to get the first dim largest eigenvectors
+    for (index d = 0; d < dim; ++d) {
+        Vector eigenvector;
+        double eigenvalue;
+        powerMethod(CC, numPivots, eigenvector, eigenvalue);
 
-		Vector pos = C * eigenvector;
+        Vector pos = C * eigenvector;
 
 #pragma omp parallel for
-		for (omp_index i = 0; i < static_cast<omp_index>(n); ++i) {
-			vertexCoordinates[i][d] = pos[i];
-		}
+        for (omp_index i = 0; i < static_cast<omp_index>(n); ++i) {
+            vertexCoordinates[i][d] = pos[i];
+        }
 
-		// remove orthogonal space spanned by the eigenvector
-		double sqNorm = eigenvector.length();
-		sqNorm *= sqNorm;
+        // remove orthogonal space spanned by the eigenvector
+        double sqNorm = eigenvector.length();
+        sqNorm *= sqNorm;
 
-		double factor = eigenvalue / sqNorm;
+        double factor = eigenvalue / sqNorm;
 
-		std::vector<Triplet> triplets;
-		for (index i = 0; i < numPivots; ++i) {
-			for (index j = 0; j < numPivots; ++j) {
-				triplets.push_back({i,j,factor * eigenvector[i] * eigenvector[j]});
-			}
-		}
+        std::vector<Triplet> triplets;
+        for (index i = 0; i < numPivots; ++i) {
+            for (index j = 0; j < numPivots; ++j) {
+                triplets.push_back(
+                    {i, j, factor * eigenvector[i] * eigenvector[j]});
+            }
+        }
 
-		CSRMatrix eigenMat(numPivots, numPivots, triplets, true);
-		CC -= eigenMat;
-	}
+        CSRMatrix eigenMat(numPivots, numPivots, triplets, true);
+        CC -= eigenMat;
+    }
 }
 
 std::vector<node> PivotMDS::computePivots() {
-	count n = G.numberOfNodes();
-	std::vector<bool> pivot(n, false);
-	std::vector<node> pivots(numPivots);
+    count n = G.numberOfNodes();
+    std::vector<bool> pivot(n, false);
+    std::vector<node> pivots(numPivots);
 
-	index pivotIdx = 0;
-	while (pivotIdx < numPivots) {
-		node pivotCandidate = G.randomNode();
-		if (!pivot[pivotCandidate]) {
-			pivots[pivotIdx++] = pivotCandidate;
-			pivot[pivotCandidate] = true;
-		}
-	}
+    index pivotIdx = 0;
+    while (pivotIdx < numPivots) {
+        node pivotCandidate = G.randomNode();
+        if (!pivot[pivotCandidate]) {
+            pivots[pivotIdx++] = pivotCandidate;
+            pivot[pivotCandidate] = true;
+        }
+    }
 
-	return pivots;
+    return pivots;
 }
 
-void PivotMDS::powerMethod(const CSRMatrix& mat, const count n, Vector& eigenvector, double& eigenvalue) {
-	eigenvector = Vector(n);
-	for (index i = 0; i < n; ++i) {
-		eigenvector[i] = 2.0*Aux::Random::real()-1.0;
-	}
+void PivotMDS::powerMethod(const CSRMatrix &mat, const count n,
+                           Vector &eigenvector, double &eigenvalue) {
+    eigenvector = Vector(n);
+    for (index i = 0; i < n; ++i) {
+        eigenvector[i] = 2.0 * Aux::Random::real() - 1.0;
+    }
 
-	Vector old;
-	count numIterations = 0;
-	do {
-		old = eigenvector;
-		eigenvector = mat * old;
-		eigenvector /= eigenvector.length();
+    Vector old;
+    count numIterations = 0;
+    do {
+        old = eigenvector;
+        eigenvector = mat * old;
+        eigenvector /= eigenvector.length();
 
-		numIterations++;
-	} while ((eigenvector - old).length() > 1e-6 && numIterations < 1500);
+        numIterations++;
+    } while ((eigenvector - old).length() > 1e-6 && numIterations < 1500);
 
-	eigenvalue = Vector::innerProduct(mat * eigenvector, eigenvector) / Vector::innerProduct(eigenvector, eigenvector);
+    eigenvalue = Vector::innerProduct(mat * eigenvector, eigenvector) /
+                 Vector::innerProduct(eigenvector, eigenvector);
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/viz/PivotMDS.cpp
+++ b/networkit/cpp/viz/PivotMDS.cpp
@@ -10,6 +10,7 @@
 #include "../../include/networkit/algebraic/CSRMatrix.hpp"
 #include "../../include/networkit/algebraic/Vector.hpp"
 
+#include "../../include/networkit/auxiliary/PrioQueue.hpp"
 #include "../../include/networkit/auxiliary/Random.hpp"
 
 #include "../../include/networkit/distance/BFS.hpp"


### PR DESCRIPTION
The original implementation of `Closeness` is not memory-efficient as it allocates a 64-bit vector of size _n_ for each call to `BFS` or `Dijkstra`; this improves the memory efficiency by pre-allocating all the necessary memory before running the algorithm.
Attached plots of speedup over the original implementation and the parallel scalability.
[speedup.pdf](https://github.com/kit-parco/networkit/files/3028070/speedup.pdf)
[parallel_scalability.pdf](https://github.com/kit-parco/networkit/files/3028071/scale.pdf)

