### PR TITLE
MacOS 10.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,49 @@ env:
 
 matrix:
   include:
+    - name: macOS 10.14, Apple Clang
+      env:
+        - CC=cc
+        - CXX=c++
+      os: osx
+      osx_image: xcode10.2
+      sudo: false
+      addons:
+        homebrew:
+          packages:
+            - libomp
+
+    - name: macOS 10.14, llvm 8
+      env:
+        - CC=/usr/local/opt/llvm@8/bin/clang
+        - CXX=/usr/local/opt/llvm@8/bin/clang++
+      os: osx
+      osx_image: xcode10.2
+      sudo: false
+      addons:
+        homebrew:
+          packages:
+            - llvm@8
+            - libomp
+
+    - name: macOS 10.14, GCC 8
+      env:
+        - CC=/usr/local/opt/gcc@8/bin/gcc-8
+        - CXX=/usr/local/opt/gcc@8/bin/g++-8
+      os: osx
+      osx_image: xcode10.2
+      sudo: false
+      addons:
+        homebrew:
+          packages:
+            - gcc@8
+      before_install:
+        - brew link gcc@8
+
     - name: macOS 10.13, llvm 8
-      env: CC=/usr/local/opt/llvm@8/bin/clang
-      env: CXX=/usr/local/opt/llvm@8/bin/clang++
+      env:
+        - CC=/usr/local/opt/llvm@8/bin/clang
+        - CXX=/usr/local/opt/llvm@8/bin/clang++
       os: osx
       osx_image: xcode10.1
       sudo: false
@@ -24,8 +64,9 @@ matrix:
           update: true
 
     - name: macOS 10.13, GCC 8
-      env: CC=/usr/local/opt/gcc@8/bin/gcc-8
-      env: CXX=/usr/local/opt/gcc@8/bin/g++-8
+      env:
+        - CC=/usr/local/opt/gcc@8/bin/gcc-8
+        - CXX=/usr/local/opt/gcc@8/bin/g++-8
       os: osx
       osx_image: xcode10.1
       sudo: false
@@ -37,8 +78,9 @@ matrix:
         - brew link gcc@8
 
     - name: macOS 10.13, Apple Clang
-      env: CC=cc
-      env: CXX=c++
+      env:
+        - CC=cc
+        - CXX=c++
       os: osx
       osx_image: xcode10.1
       sudo: false
@@ -47,37 +89,10 @@ matrix:
           packages:
             - libomp
 
-    - name: macOS 10.12, llvm 7
-      env: CC=/usr/local/opt/llvm@7/bin/clang
-      env: CXX=/usr/local/opt/llvm@7/bin/clang++
-      os: osx
-      osx_image: xcode9.2
-      sudo: false
-      addons:
-        homebrew:
-          packages:
-            - llvm@7
-            - libomp
-            - python
-          update: true
-
-    - name: macOS 10.12, GCC 8
-      env: CC=/usr/local/opt/gcc@8/bin/gcc-8
-      env: CXX=/usr/local/opt/gcc@8/bin/g++-8
-      os: osx
-      osx_image: xcode9.2
-      sudo: false
-      addons:
-        homebrew:
-          packages:
-            - gcc@8
-            - python
-          update: true
-      before_install:
-        - brew link gcc@8
-
     - name: Linux, GCC 8
-      env: CC=gcc-8 CXX=g++-8
+      env:
+        - CC=gcc-8
+        - CXX=g++-8
       os: linux
       dist: xenial
       addons: &gcc8
@@ -90,7 +105,9 @@ matrix:
             - python3.5-venv
 
     - name: Linux, GCC 4.9
-      env: CC=gcc-4.9 CXX=g++-4.9
+      env:
+        - CC=gcc-4.9
+        - CXX=g++-4.9
       os: linux
       dist: xenial
       sudo: false
@@ -105,7 +122,9 @@ matrix:
             - python3.5-venv
 
     - name: Linux, Clang 3.8
-      env: CC=clang-3.8 CXX=clang++-3.8
+      env:
+        - CC=clang-3.8
+        - CXX=clang++-3.8
       os: linux
       dist: xenial
       sudo: false
@@ -122,7 +141,9 @@ matrix:
 
     # Test more exotic builds only on Linux.
     - name: "Linux, GCC 8: Core build, debugging"
-      env: CC=gcc-8 CXX=g++-8
+      env:
+        - CC=gcc-8
+        - CXX=g++-8
       os: linux
       dist: xenial
       addons: *gcc8
@@ -134,7 +155,9 @@ matrix:
         - ctest -V
 
     - name: "Linux, GCC 8: Core build, non-monolithic"
-      env: CC=gcc-8 CXX=g++-8
+      env:
+        - CC=gcc-8
+        - CXX=g++-8
       os: linux
       dist: xenial
       addons: *gcc8
@@ -147,7 +170,10 @@ matrix:
 
     # Finally, test conformance to newer versions of the C++ standard.
     - name: "Linux, GCC 8: C++14 conformance"
-      env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=14
+      env:
+        - CC=gcc-8
+        - CXX=g++-8
+        - CXX_STANDARD=14
       os: linux
       dist: xenial
       addons: *gcc8
@@ -159,14 +185,19 @@ matrix:
         - ctest -V
 
     - name: "Linux, GCC 8: C++17 conformance"
-      env: CC=gcc-8 CXX=g++-8 CXX_STANDARD=17
+      env:
+        - CC=gcc-8
+        - CXX=g++-8
+        - CXX_STANDARD=17
       os: linux
       dist: xenial
       addons: *gcc8
       script: *script_cpp_only
 
     - name: Documentation only
-      env: CC=gcc-8 CXX=g++-8
+      env:
+        - CC=gcc-8
+        - CXX=g++-8
       os: linux
       dist: xenial
       addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,18 +75,17 @@ else()
 endif()
 
 
-# AppleClang support is added in CMake > 3.12
-# the following passage checks if CMake > 3.12 is installed and manually
-# links the omp lib if found
+# FindOpenMP.cmake does not reliably find a user installed openmp library
+# Following section manually sets the required fields for clang-like compiler
 if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
 	"${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 	find_library(LIBOMP_PATH NAMES omp HINTS "/usr/local/opt/libomp/include")
 	find_path(LIBOMP_INCLUDE NAMES omp.h HINTS "/usr/local/opt/libomp/include")
 	if(LIBOMP_PATH AND LIBOMP_INCLUDE)
 		if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-			set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set OpenMP CXX flags")
+			set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set")
 		elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-			set(OpenMP_CXX_FLAGS "-fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set OpenMP CXX flags")
+			set(OpenMP_CXX_FLAGS "-fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set")
 		endif()
 		set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "Manually set")
 		set(OpenMP_omp_LIBRARY "${LIBOMP_PATH}" CACHE STRING "Manually set")
@@ -95,7 +94,7 @@ if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
 	endif()
 endif()
 
-# adding OpenMP flags
+# finding or creating OpenMP target
 find_package(OpenMP REQUIRED)
 if(NOT TARGET OpenMP::OpenMP_CXX)
 	message("Creating custom OpenMP target for CMake Version < 3.12. Current CMake Version ${CMAKE_VERSION}")
@@ -104,7 +103,7 @@ if(NOT TARGET OpenMP::OpenMP_CXX)
 	set_property(TARGET OpenMP::OpenMP_CXX
 				 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
 	set_property(TARGET OpenMP::OpenMP_CXX
-				 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_LIBRARIES} Threads::Threads)
+				 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
 endif()
 
 if (CMAKE_SIZEOF_VOID_P LESS 8)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,30 +78,33 @@ endif()
 # AppleClang support is added in CMake > 3.12
 # the following passage checks if CMake > 3.12 is installed and manually
 # links the omp lib if found
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-	if(${CMAKE_VERSION} VERSION_LESS 3.12)
- 		message(WARNING "OpenMP linking with AppleClang was introduced in CMake 3.12. Current CMake Version ${CMAKE_VERSION}")
-	else()
-		find_library(OMP_FOUND NAMES omp)
-		if(OMP_FOUND)
-			set(NETWORKIT_LINK_FLAGS "-lomp ${NETWORKIT_LINK_FLAGS}")
-		else()
-			message(FATAL_ERROR "libomp was not found, but necessary to run NetworKit with AppleClang")
+if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
+	"${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+	find_library(LIBOMP_PATH NAMES omp HINTS "/usr/local/opt/libomp/include")
+	find_path(LIBOMP_INCLUDE NAMES omp.h HINTS "/usr/local/opt/libomp/include")
+	if(LIBOMP_PATH AND LIBOMP_INCLUDE)
+		if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+			set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set OpenMP CXX flags")
+		elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+			set(OpenMP_CXX_FLAGS "-fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set OpenMP CXX flags")
 		endif()
+		set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "Manually set")
+		set(OpenMP_omp_LIBRARY "${LIBOMP_PATH}" CACHE STRING "Manually set")
+	else()
+		message(FATAL_ERROR "libomp was not found, but necessary to run NetworKit with AppleClang")
 	endif()
  endif()
 
 # adding OpenMP flags
 find_package(OpenMP REQUIRED)
-if(OPENMP_FOUND)
-	set(NETWORKIT_CXX_FLAGS "${NETWORKIT_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-
-	if (NOT MSVC)
-		# In MSVC /openmp is only passed to the compiler, and must not be passed to the linker to avoid warnigns
-		set(NETWORKIT_LINK_FLAGS "${NETWORKIT_LINK_FLAGS} ${OpenMP_CXX_FLAGS}")
-	endif()
-else()
-	message(FATAL_ERROR "OpenMP not found")
+if(NOT TARGET OpenMP::OpenMP_CXX)
+	message("Creating custom OpenMP target for CMake Version < 3.12. Current CMake Version ${CMAKE_VERSION}")
+	find_package(Threads REQUIRED)
+	add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+	set_property(TARGET OpenMP::OpenMP_CXX
+				 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+	set_property(TARGET OpenMP::OpenMP_CXX
+				 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_LIBRARIES} Threads::Threads)
 endif()
 
 if (CMAKE_SIZEOF_VOID_P LESS 8)
@@ -167,7 +170,7 @@ if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 			LIBRARY DESTINATION ${NETWORKIT_LIB_DEST}
 			ARCHIVE DESTINATION ${NETWORKIT_LIB_DEST})
 
-	target_link_libraries(networkit PRIVATE tlx)
+	target_link_libraries(networkit PRIVATE tlx OpenMP::OpenMP_CXX)
 endif()
 
 if(NETWORKIT_PYTHON)
@@ -202,7 +205,7 @@ if(NETWORKIT_PYTHON)
 				INSTALL_RPATH "$ORIGIN")
 	endif()
 
-    target_link_libraries(_NetworKit PRIVATE tlx)
+	target_link_libraries(_NetworKit PRIVATE tlx OpenMP::OpenMP_CXX)
 
 	install(TARGETS _NetworKit
 			LIBRARY DESTINATION ${NETWORKIT_LIB_DEST})
@@ -230,7 +233,7 @@ function(networkit_add_module modname)
 			COMPILE_FLAGS "${NETWORKIT_CXX_FLAGS}"
 			LINK_FLAGS "${NETWORKIT_LINK_FLAGS}")
 
-		target_link_libraries(${MODULE_TARGET} PRIVATE tlx)
+		target_link_libraries(${MODULE_TARGET} PRIVATE tlx OpenMP::OpenMP_CXX)
 
 		# All tests added to this module will will also become a dependency
 		# of networkit_tests_MODNAME. This target hence allows to build all
@@ -317,6 +320,7 @@ if (NETWORKIT_BUILD_TESTS)
 				gtest
 				networkit
 				tlx
+				OpenMP::OpenMP_CXX
 		)
 
 		set_target_properties(networkit_tests PROPERTIES
@@ -373,6 +377,7 @@ function(networkit_add_extra IS_TEST MOD NAME)
 				PRIVATE
 					networkit_${MOD}
 					tlx
+					OpenMP::OpenMP_CXX
 					)
 			set_target_properties(${TARGET_NAME} PROPERTIES
 				CXX_STANDARD ${NETWORKIT_CXX_STANDARD}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
 	else()
 		message(FATAL_ERROR "libomp was not found, but necessary to run NetworKit with AppleClang")
 	endif()
- endif()
+endif()
 
 # adding OpenMP flags
 find_package(OpenMP REQUIRED)


### PR DESCRIPTION
This PR incorporates the new macOS travis config introduced here: https://github.com/kit-parco/networkit/pull/310

Also `CMakeLists.txt` is adapted to manually set compile and linking flags for clang-like compiler.

Regarding https://github.com/kit-parco/networkit/pull/310#issuecomment-481229629:
We could get rid of the `find_library` and `find_path` parts by assuming the installed libomp is properly linked (as e.g. homebrew does by default), but that might be less robust.

Also, the OpenMP::OpenMP_CXX target is manually created if it does not exist, although that's never tested in CI. The travis linux images got a package update and cmake has version 3.12.4 now.