### PR TITLE
New Graph method: toLargestConnectedComponent()

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -840,6 +840,12 @@ class Graph final {
 
     Graph subgraphFromNodes(const std::unordered_set<node> &nodes) const;
 
+    /**
+     * Deletes all nodes and edges not in the largest connected component. Only
+     * available for undirected graphs.
+     */
+    void toLargestConnectedComponent();
+
     /** NODE PROPERTIES **/
 
     /**

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -352,7 +352,8 @@ cdef extern from "../include/networkit/graph/Graph.hpp":
 		void DFSfrom[Callback](node r, Callback c) except +
 		void DFSEdgesFrom[Callback](node r, Callback c) except +
 		bool_t checkConsistency() except +
-		_Graph subgraphFromNodes(unordered_set[node] nodes)  except +
+		_Graph subgraphFromNodes(unordered_set[node] nodes) except +
+		void toLargestConnectedComponent() except +
 
 cdef cppclass EdgeCallBackWrapper:
 	void* callback
@@ -1329,6 +1330,15 @@ cdef class Graph:
 		for node in nodes:
 			nnodes.insert(node)
 		return Graph().setThis(self._this.subgraphFromNodes(nnodes))
+
+	def toLargestConnectedComponent(self):
+		""" Deletes all nodes and edges not in the largest connected component.
+
+		Notes
+		-----
+		Available for undirected graphs only.
+		"""
+		self._this.toLargestConnectedComponent()
 
 # TODO: expose all methods
 

--- a/networkit/cpp/graph/Graph.cpp
+++ b/networkit/cpp/graph/Graph.cpp
@@ -9,7 +9,10 @@
 #include <cmath>
 #include <random>
 #include <sstream>
+#include<unordered_map>
+#include<unordered_set>
 
+#include "../../include/networkit/components/ConnectedComponents.hpp"
 #include "../../include/networkit/graph/Graph.hpp"
 #include "../../include/networkit/graph/GraphBuilder.hpp"
 
@@ -1065,4 +1068,52 @@ Graph Graph::subgraphFromNodes(const std::unordered_set<node> &nodes) const {
 	return S;
 }
 
+void Graph::toLargestConnectedComponent() {
+	if (this->isDirected())
+		throw std::runtime_error(
+			"Method available for undirected graphs only.");
+
+	ConnectedComponents cc(*this);
+	cc.run();
+	auto comps = cc.getComponents();
+	std::sort(comps.begin(), comps.end(),
+		[&](const std::vector<node> &x, const std::vector<node> &y) {
+			return x.size() > y.size();
+	});
+	std::unordered_map<node, node> map;
+	std::unordered_set<node> set(comps[0].begin(), comps[0].end());
+	node idx = 0;
+	for (node u : comps[0])
+		map[u] = idx++;
+	std::vector<std::pair<node, node>> edges;
+	std::vector<edgeweight> weights;
+	this->subgraphFromNodes(set).forEdges([&](node x, node y, edgeweight w) {
+		if (map[x] != map[y]) {
+			edges.push_back(std::make_pair(map[x], map[y]));
+			if (this->isWeighted())
+				weights.push_back(w);
+		}
+	});
+
+	n = idx;
+	z = n;
+	m = 0;
+	storedNumberOfSelfLoops = 0;
+	outEdges.clear();
+	outEdges.resize(n);
+	inEdges.clear();
+	inEdges.resize(n);
+	inEdgeWeights.clear();
+	inEdgeWeights.resize(n);
+	outEdgeWeights.clear();
+	outEdgeWeights.resize(n);
+	exists.clear();
+	exists.resize(n, true);
+
+	for (count e = 0; e < edges.size(); ++e) {
+		this->addEdge(edges[e].first, edges[e].second);
+		if (this->isWeighted())
+			this->setWeight(edges[e].first, edges[e].second, weights[e]);
+	}
+}
 } /* namespace NetworKit */

--- a/networkit/cpp/graph/test/GraphGTest.cpp
+++ b/networkit/cpp/graph/test/GraphGTest.cpp
@@ -2279,4 +2279,18 @@ TEST_P(GraphGTest, testSortEdges) {
 	}
 }
 
+TEST_P(GraphGTest, testToLargestConnectedComponent) {
+	Graph G(8);
+	G.addEdge(0, 1);
+	G.addEdge(2, 1);
+	G.addEdge(3, 1);
+	G.addEdge(4, 1);
+
+	G.addEdge(5, 6);
+
+	G.toLargestConnectedComponent();
+	EXPECT_EQ(G.numberOfNodes(), 5);
+	EXPECT_EQ(G.upperNodeIdBound(), 5);
+	EXPECT_EQ(G.numberOfEdges(), 4);
+}
 } /* namespace NetworKit */


### PR DESCRIPTION
New method that deletes all nodes and edges not in the largest connected component of a graph. Only works for undirected graphs.