### PR TITLE
New method: extractLargestConnectedComponent

### DIFF
--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -103,8 +103,17 @@ Graph getRemappedGraph(const Graph& graph, count numNodes, UnaryIdMapper&& oldId
         std::forward<UnaryIdMapper>(oldIdToNew), [](node) { return false; }, preallocate);
 }
 
+/**
+ * Constructs a new graph that contains only the nodes inside the largest
+ * connected component.
+ * @param G            The input graph.
+ * @param compactGraph If true, the node ids of the output graph will be compacted
+ * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
+ */
+Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
+
+
 }	// namespace GraphTools
 }	// namespace NetworKit
 
 #endif // GRAPHTOOLS_H
-

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -4522,6 +4522,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
+	_Graph extractLargestConnectedComponent(_Graph G, bool_t) nogil except +
 
 cdef class GraphTools:
 	@staticmethod
@@ -4559,6 +4560,34 @@ cdef class GraphTools:
 		for elem in cResult:
 			result[elem.first] = elem.second
 		return result
+
+	@staticmethod
+	def extractLargestConnectedComponent(Graph graph, bool_t compactGraph = False):
+		"""
+			Constructs a new graph that contains only the nodes inside the
+			largest connected component.
+
+			Parameters
+			----------
+			graph: networkit.Graph
+				The input graph
+			compactGraph: bool
+				if true, the node ids of the output graph will be compacted
+				(i.e., re-numbered from 0 to n-1). If false, the node ids
+				will not be changed.
+
+			Returns
+			-------
+			networkit.Graph
+				A graph that contains only the nodes inside the largest
+				connected component.
+
+
+			Note
+			----
+			Available for undirected graphs only.
+		"""
+		return Graph().setThis(extractLargestConnectedComponent(graph._this, compactGraph))
 
 
 cdef extern from "<networkit/community/PartitionIntersection.hpp>":

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,7 +1,10 @@
-#include <networkit/graph/GraphTools.hpp>
-#include <unordered_map>
-#include <networkit/graph/Graph.hpp>
+#include <algorithm>
 #include <random>
+#include <unordered_map>
+
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -24,7 +27,6 @@ std::unordered_map<node,node> getContinuousNodeIds(const Graph& graph) {
 	graph.forNodes(addToMap);
 	return nodeIdMap;
 }
-
 std::unordered_map<node,node> getRandomContinuousNodeIds(const Graph& graph) {
 	std::unordered_map<node,node> nodeIdMap;
 	std::vector<node> nodes;
@@ -73,6 +75,47 @@ Graph restoreGraph(const std::vector<node>& invertedIdMap, const Graph& G) {
 	return Goriginal;
 }
 
+Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph) {
+	if (!G.numberOfNodes())
+		return G;
+
+	ConnectedComponents cc(G);
+	cc.run();
+
+	auto compSizes = cc.getComponentSizes();
+	if (compSizes.size() == 1)
+			return G;
+
+	auto largestCC = std::max_element(
+		compSizes.begin(), compSizes.end(),
+		[](const std::pair<index, count> &x, const std::pair<index, count> &y) {
+			return x.second < y.second;
+		});
+
+	std::unordered_map<node, node> continuousNodeIds;
+	index nextId = 0;
+	G.forNodes([&](node u) {
+		if (cc.componentOfNode(u) == largestCC->first)
+			continuousNodeIds[u] = nextId++;
+	});
+
+	if (compactGraph) {
+		Graph S = getRemappedGraph(G, largestCC->second,
+			[&](node u) { return continuousNodeIds[u]; },
+			[&](node u) { return cc.componentOfNode(u) != largestCC->first; });
+		return S;
+	} else {
+		Graph S(G);
+		auto components = cc.getComponents();
+		for (count i = 0; i < components.size(); ++i) {
+			if (i != largestCC->first) {
+				for (node u : components[i])
+					S.removeNode(u);
+			}
+		}
+		return S;
+	}
+}
+
 } // namespace GraphTools
 } // namespace NetworKit
-

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -59,12 +59,12 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphUndirectedUnweighted1) {
 
 	auto nodeMap = GraphTools::getContinuousNodeIds(G);
 	auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
-	
+
 	EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
 	EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
 	EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
 	EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
-	// TODOish: find a deeper test to check if the structure of the graphs are the same, 
+	// TODOish: find a deeper test to check if the structure of the graphs are the same,
 	// probably compare results of some algorithms or compare each edge with a reference node id map.
 }
 
@@ -83,13 +83,13 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphUndirectedUnweighted2) {
 
 	auto nodeMap = GraphTools::getContinuousNodeIds(G);
 	auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
-	
+
 	EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
 	EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
 	EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
 	EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
 	EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
-	// TODOish: find a deeper test to check if the structure of the graphs are the same, 
+	// TODOish: find a deeper test to check if the structure of the graphs are the same,
 	// probably compare results of some algorithms or compare each edge with a reference node id map.
 }
 
@@ -108,14 +108,14 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphUndirectedWeighted1) {
 
 	auto nodeMap = GraphTools::getContinuousNodeIds(G);
 	auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
-	
+
 	EXPECT_EQ(G.totalEdgeWeight(),Gcompact.totalEdgeWeight());
 	EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
 	EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
 	EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
 	EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
 	EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
-	// TODOish: find a deeper test to check if the structure of the graphs are the same, 
+	// TODOish: find a deeper test to check if the structure of the graphs are the same,
 	// probably compare results of some algorithms or compare each edge with a reference node id map.
 }
 
@@ -134,14 +134,14 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphDirectedWeighted1) {
 
 	auto nodeMap = GraphTools::getContinuousNodeIds(G);
 	auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
-	
+
 	EXPECT_EQ(G.totalEdgeWeight(),Gcompact.totalEdgeWeight());
 	EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
 	EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
 	EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
 	EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
 	EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
-	// TODOish: find a deeper test to check if the structure of the graphs are the same, 
+	// TODOish: find a deeper test to check if the structure of the graphs are the same,
 	// probably compare results of some algorithms or compare each edge with a reference node id map.
 }
 
@@ -159,14 +159,14 @@ TEST_F(GraphToolsGTest, testGetCompactedGraphDirectedUnweighted1) {
 	G.addEdge(1,9);
 	auto nodeMap = GraphTools::getContinuousNodeIds(G);
 	auto Gcompact = GraphTools::getCompactedGraph(G,nodeMap);
-	
+
 	EXPECT_EQ(G.totalEdgeWeight(),Gcompact.totalEdgeWeight());
 	EXPECT_NE(G.upperNodeIdBound(),Gcompact.upperNodeIdBound());
 	EXPECT_EQ(G.numberOfNodes(),Gcompact.numberOfNodes());
 	EXPECT_EQ(G.numberOfEdges(),Gcompact.numberOfEdges());
 	EXPECT_EQ(G.isDirected(),Gcompact.isDirected());
 	EXPECT_EQ(G.isWeighted(),Gcompact.isWeighted());
-	// TODOish: find a deeper test to check if the structure of the graphs are the same, 
+	// TODOish: find a deeper test to check if the structure of the graphs are the same,
 	// probably compare results of some algorithms or compare each edge with a reference node id map.
 }
 
@@ -303,5 +303,26 @@ TEST_F(GraphToolsGTest, testGetRemappedGraphWithDelete) {
 	}
 }
 
+TEST_F(GraphToolsGTest, testExtractLargestConnectedComponent) {
+	Graph G(8);
 
+	G.addEdge(0, 1);
+	G.addEdge(2, 1);
+	G.addEdge(3, 1);
+	G.addEdge(4, 1);
+
+	G.addEdge(5, 6);
+	Graph G1(G);
+
+	G = GraphTools::extractLargestConnectedComponent(G, true);
+	EXPECT_EQ(G.numberOfNodes(), 5);
+	EXPECT_EQ(G.upperNodeIdBound(), 5);
+	EXPECT_EQ(G.numberOfEdges(), 4);
+
+	G1 = GraphTools::extractLargestConnectedComponent(G1, false);
+	EXPECT_EQ(G1.numberOfNodes(), 5);
+	EXPECT_EQ(G1.upperNodeIdBound(), 8);
+	EXPECT_EQ(G1.numberOfEdges(), 4);
 }
+
+} // namespace NetworKit


### PR DESCRIPTION
Even though `extractLargestComponent` already exists in `workflows.py`, this algorithm is not available in C++. This commit brings a more efficient C++ implementation of the same algorithm, which can additionally "compact" the graph.