### PR TITLE
New travis build: Linux with gcc 9. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,6 @@ env:
 
 matrix:
   include:
-    - name: macOS 10.14, Apple Clang
-      env:
-        - CC=cc
-        - CXX=c++
-      os: osx
-      osx_image: xcode10.2
-      sudo: false
-      addons:
-        homebrew:
-          packages:
-            - libomp
-
     - name: macOS 10.14, llvm 8
       env:
         - CC=/usr/local/opt/llvm@8/bin/clang
@@ -48,6 +36,18 @@ matrix:
             - gcc@8
       before_install:
         - brew link gcc@8
+
+    - name: macOS 10.14, Apple Clang
+      env:
+        - CC=cc
+        - CXX=c++
+      os: osx
+      osx_image: xcode10.2
+      sudo: false
+      addons:
+        homebrew:
+          packages:
+            - libomp
 
     - name: macOS 10.13, llvm 8
       env:
@@ -88,6 +88,21 @@ matrix:
         homebrew:
           packages:
             - libomp
+
+    - name: Linux, GCC 9
+      env:
+        - CC=gcc-9
+        - CXX=g++-9
+      os: linux
+      dist: xenial
+      addons: &gcc9
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+            - python3-pip
+            - python3.5-venv
 
     - name: Linux, GCC 8
       env:


### PR DESCRIPTION
Added new travis build with gcc 9 on Linux, this should not increase the time of travis builds as the bottleneck are Apple builds. Also, re-sorted Apple builds.