### PR TITLE
Add missing OpenMP dependency for non-monolith tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,8 +345,12 @@ if (NETWORKIT_BUILD_TESTS)
 	else()
 		add_library(networkit_gtest_main STATIC networkit/cpp/Unittests-X.cpp)
 		target_link_libraries(networkit_gtest_main
-				PUBLIC gtest
-				PRIVATE networkit_auxiliary)
+				PUBLIC
+					gtest
+				PRIVATE
+					networkit_auxiliary
+					OpenMP::OpenMP_CXX
+		)
 	endif()
 endif()
 


### PR DESCRIPTION
Non-monolithic build fails using default OSX compiler. While this is clearly a bug on our part, I like to blame the accessory manufacturer (the one selling monitor stands for 1k USD) for not shipping OpenMP ;)