### PR TITLE
More efficient memory allocation for APSP

### DIFF
--- a/include/networkit/distance/APSP.hpp
+++ b/include/networkit/distance/APSP.hpp
@@ -8,8 +8,8 @@
 #ifndef APSP_H_
 #define APSP_H_
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/base/Algorithm.hpp>
+#include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
 
@@ -17,57 +17,55 @@ namespace NetworKit {
  * @ingroup distance
  * Class for all-pair shortest path algorithm.
  */
-class APSP: public Algorithm {
+class APSP : public Algorithm {
 
-public:
+  public:
+    /**
+     * Creates the APSP class for @a G.
+     *
+     * @param G The graph.
+     */
+    APSP(const Graph &G);
 
-	/**
-	 * Creates the APSP class for @a G.
-	 *
-	 * @param G The graph.
-	 */
-	APSP(const Graph& G);
+    virtual ~APSP() = default;
 
-	virtual ~APSP() = default;
+    /** Computes the shortest paths from each node to all other nodes. */
+    void run() override;
 
-	/** Computes the shortest paths from each node to all other nodes. */
-	void run() override;
+    /**
+     * @return string representation of algorithm and parameters.
+     */
+    virtual std::string toString() const override;
 
-	/**
-	* @return string representation of algorithm and parameters.
-	*/
-	virtual std::string toString() const override;
+    /**
+     * Returns a vector of weighted distances between node pairs.
+     *
+     * @return The shortest-path distances from each node to any other node in
+     * the graph.
+     */
+    std::vector<std::vector<edgeweight>> getDistances() const {
+        assureFinished();
+        return distances;
+    }
 
-	/**
-	 * Returns a vector of weighted distances between node pairs.
- 	 *
- 	 * @return The shortest-path distances from each node to any other node in the graph.
-	 */
-	std::vector<std::vector<edgeweight>> getDistances() const {
-		assureFinished();
-		return distances;
-	}
+    /**
+     * Returns the distance from u to v or infinity if u and v are not
+     * connected.
+     *
+     */
+    edgeweight getDistance(node u, node v) const {
+        assureFinished();
+        return distances[u][v];
+    }
 
+    /**
+     * @return True if algorithm can run multi-threaded.
+     */
+    virtual bool isParallel() const override { return true; }
 
-	/**
-	 * Returns the distance from u to v or infinity if u and v are not connected.
-	 *
-	 */
-	edgeweight getDistance(node u, node v) const {
-		assureFinished();
-		return distances[u][v];
-	}
-
-	/**
-	* @return True if algorithm can run multi-threaded.
-	*/
-	virtual bool isParallel() const override { return true; }
-
-
-protected:
-
-	const Graph& G;
-	std::vector<std::vector<edgeweight> > distances;
+  protected:
+    const Graph &G;
+    std::vector<std::vector<edgeweight>> distances;
 };
 
 } /* namespace NetworKit */

--- a/include/networkit/distance/APSP.hpp
+++ b/include/networkit/distance/APSP.hpp
@@ -8,7 +8,10 @@
 #ifndef APSP_H_
 #define APSP_H_
 
+#include <memory>
+
 #include <networkit/base/Algorithm.hpp>
+#include <networkit/distance/SSSP.hpp>
 #include <networkit/graph/Graph.hpp>
 
 namespace NetworKit {
@@ -66,6 +69,7 @@ class APSP : public Algorithm {
   protected:
     const Graph &G;
     std::vector<std::vector<edgeweight>> distances;
+    std::vector<std::unique_ptr<SSSP>> sssps;
 };
 
 } /* namespace NetworKit */

--- a/networkit/cpp/distance/APSP.cpp
+++ b/networkit/cpp/distance/APSP.cpp
@@ -5,36 +5,36 @@
  *      Author: Arie Slobbe
  */
 
-#include <networkit/distance/APSP.hpp>
 #include <networkit/auxiliary/Log.hpp>
-#include <networkit/distance/Dijkstra.hpp>
+#include <networkit/distance/APSP.hpp>
 #include <networkit/distance/BFS.hpp>
+#include <networkit/distance/Dijkstra.hpp>
 
 namespace NetworKit {
 
-APSP::APSP(const Graph& G) : Algorithm(), G(G) {}
+APSP::APSP(const Graph &G) : Algorithm(), G(G) {}
 
 void APSP::run() {
-	std::vector<edgeweight> distanceVector(G.upperNodeIdBound(), 0.0);
-	distances.resize(G.upperNodeIdBound(), distanceVector);
-	if (G.isWeighted()) {
-		G.parallelForNodes([&](node u){
-			Dijkstra dijk(G, u);
-			dijk.run();
-			distances[u] = dijk.getDistances();
-		});
-	} else {
-		G.parallelForNodes([&](node u){
-			BFS bfs(G, u);
-			bfs.run();
-			distances[u] = bfs.getDistances();
-		});
-	}
-	hasRun = true;
+    std::vector<edgeweight> distanceVector(G.upperNodeIdBound(), 0.0);
+    distances.resize(G.upperNodeIdBound(), distanceVector);
+    if (G.isWeighted()) {
+        G.parallelForNodes([&](node u) {
+            Dijkstra dijk(G, u);
+            dijk.run();
+            distances[u] = dijk.getDistances();
+        });
+    } else {
+        G.parallelForNodes([&](node u) {
+            BFS bfs(G, u);
+            bfs.run();
+            distances[u] = bfs.getDistances();
+        });
+    }
+    hasRun = true;
 }
 
 std::string APSP::toString() const {
-	return "All-Pairs Shortest Path Algorithm";
+    return "All-Pairs Shortest Path Algorithm";
 }
 
 } /* namespace NetworKit */

--- a/networkit/cpp/distance/APSP.cpp
+++ b/networkit/cpp/distance/APSP.cpp
@@ -5,7 +5,8 @@
  *      Author: Arie Slobbe
  */
 
-#include <networkit/auxiliary/Log.hpp>
+#include <omp.h>
+
 #include <networkit/distance/APSP.hpp>
 #include <networkit/distance/BFS.hpp>
 #include <networkit/distance/Dijkstra.hpp>
@@ -15,21 +16,29 @@ namespace NetworKit {
 APSP::APSP(const Graph &G) : Algorithm(), G(G) {}
 
 void APSP::run() {
-    std::vector<edgeweight> distanceVector(G.upperNodeIdBound(), 0.0);
-    distances.resize(G.upperNodeIdBound(), distanceVector);
-    if (G.isWeighted()) {
-        G.parallelForNodes([&](node u) {
-            Dijkstra dijk(G, u);
-            dijk.run();
-            distances[u] = dijk.getDistances();
-        });
-    } else {
-        G.parallelForNodes([&](node u) {
-            BFS bfs(G, u);
-            bfs.run();
-            distances[u] = bfs.getDistances();
-        });
+    count n = G.upperNodeIdBound();
+    std::vector<edgeweight> distanceVector(n, 0.0);
+    distances.resize(n, distanceVector);
+
+    count nThreads = omp_get_max_threads();
+    sssps.resize(nThreads);
+#pragma omp parallel
+    {
+        omp_index i = omp_get_thread_num();
+        if (G.isWeighted())
+            sssps[i] = std::unique_ptr<SSSP>(new Dijkstra(G, 0, false));
+        else
+            sssps[i] = std::unique_ptr<SSSP>(new BFS(G, 0, false));
     }
+
+#pragma omp parallel for schedule(dynamic)
+    for (omp_index source = 0; source < n; ++source) {
+        auto sssp = sssps[omp_get_thread_num()].get();
+        sssp->setSource(source);
+        sssp->run();
+        distances[source] = sssp->getDistances();
+    }
+
     hasRun = true;
 }
 


### PR DESCRIPTION
This improves the memory footprint of APSP by avoid dynamic allocations when running BFS/Dijkstra
(all the necessary space is allocated once). The new implementation is now 1.5x to 4x faster than the original one.