### PR TITLE
CMake flags for sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ option(NETWORKIT_INCLUDESYMLINK "Create symlink to cpp directory" ON)
 option(NETWORKIT_FLATINSTALL "Install into a flat directory structure (useful when building a Python package)" OFF)
 set(NETWORKIT_PYTHON "" CACHE STRING "Directory containing Python.h. Implies MONOLITH=TRUE")
 set(NETWORKIT_PYTHON_SOABI "" CACHE STRING "Platform specific file extension. Implies MONOLITH=TRUE")
+set(NETWORKIT_WITH_SANITIZERS "" CACHE STRING "Uses sanitizers during the compilation")
+set(NETWORKIT_CXX_SANITIZERS "")
 
 set (NETWORKIT_CXX_STANDARD "11" CACHE STRING "CXX Version to compile with. Currently fixed to 11")
 
@@ -74,6 +76,18 @@ else()
 	message(WARNING "Support only GCC, Clang, MSVC and AppleClang. Your compiler may or may not work.")
 endif()
 
+# Checking sanitizer options; in both cases we include 'undefined'
+if ("${NETWORKIT_WITH_SANITIZERS}" STREQUAL "address")
+	set(NETWORKIT_CXX_SANITIZERS "address,undefined")
+elseif ("${NETWORKIT_WITH_SANITIZERS}" STREQUAL "leak")
+	set(NETWORKIT_CXX_SANITIZERS "address,leak,undefined")
+elseif(NOT "${NETWORKIT_WITH_SANITIZERS}" STREQUAL "")
+	message(FATAL_ERROR "Unsupported option ${NETWORKIT_WITH_SANITIZERS}")
+endif()
+
+if (NOT "${NETWORKIT_CXX_SANITIZERS}" STREQUAL "")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${NETWORKIT_CXX_SANITIZERS}")
+endif()
 
 # FindOpenMP.cmake does not reliably find a user installed openmp library
 # Following section manually sets the required fields for clang-like compiler

--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ Single tests can be executed with:
 Additionally, one can specify the level of the logs outputs by adding `--loglevel=<log_level>`;
 supported log levels are: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, and `FATAL`.
 
+### Compiling with address/leak sanitizers
+
+Address and leak sanitizers are very useful tools to test if your code produces memory errors/leaks.
+To compile your code with sanitizers, set the [CMake] `NETWORKIT_WITH_SANITIZERS` to either `address` or `leak`:
+
+	cmake -DNETWORKIT_WITH_SANITIZERS='leak'
+
+By setting this flag to `address`, your code will be compiled with the `address` and the `undefined` sanitizers.
+Setting it to `leak` also adds the `leak` sanitizer.
+
 ## Known Issues
 - Mac OS X 10.10 "Yosemite": Some users have reported compilation problems on Yosemite with g++ 4.9. The compiler errors mention register problems.
   While the exact reason remains unclear, the actual issue seems to be that the compiler tries to perform a dual architecture build.


### PR DESCRIPTION
This facilitates compiling NetworKit with address/leak sanitizers. The `NETWORKIT_WITH_SANITIZERS` flag can be set to `address` or `leak` to enable the address or address+leak sanitizers. In both cases, the undefined sanitizer is also used.