### PR TITLE
Refactor SSSP getDistances()

### DIFF
--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -13,6 +13,7 @@
 
 #include <networkit/base/Algorithm.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <tlx/define/deprecated.hpp>
 
 namespace NetworKit {
 
@@ -51,7 +52,8 @@ class SSSP : public Algorithm {
      * @return The weighted distances from the source node to any other node in
      * the graph.
      */
-    virtual std::vector<edgeweight> getDistances(bool moveOut = true);
+    std::vector<edgeweight> TLX_DEPRECATED(getDistances(bool moveOut));
+    const std::vector<edgeweight> &getDistances();
 
     /**
      * Returns the distance from the source node to @a t.
@@ -121,7 +123,8 @@ class SSSP : public Algorithm {
      *class instead of copying it; default=true.
      * @return vector of nodes ordered in increasing distance from the source
      */
-    virtual std::vector<node> getNodesSortedByDistance(bool moveOut = true);
+    std::vector<node> TLX_DEPRECATED(getNodesSortedByDistance(bool moveOut));
+    const std::vector<node> &getNodesSortedByDistance() const;
 
     /**
      * Returns the number of nodes reached by the source.

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -95,7 +95,7 @@ class SSSP : public Algorithm {
      * @a t, otherwise the path is reversed.
      * @return A shortest path from source to @a t or an empty path.
      */
-    virtual std::vector<node> getPath(node t, bool forward = true) const;
+    std::vector<node> getPath(node t, bool forward = true) const;
 
     /**
      * Returns all shortest paths from source to @a t and an empty set if source
@@ -106,8 +106,7 @@ class SSSP : public Algorithm {
      * @a t, otherwise the path is reversed.
      * @return All shortest paths from source node to target node @a t.
      */
-    virtual std::set<std::vector<node>> getPaths(node t,
-                                                 bool forward = true) const;
+    std::set<std::vector<node>> getPaths(node t, bool forward = true) const;
 
     /* Returns the number of shortest paths to node t.*/
     bigfloat getNumberOfPaths(node t) const;

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -1340,6 +1340,7 @@ cdef extern from "<networkit/distance/SSSP.hpp>":
 	cdef cppclass _SSSP "NetworKit::SSSP"(_Algorithm):
 		_SSSP(_Graph G, node source, bool_t storePaths, bool_t storeNodesSortedByDistance, node target) except +
 		vector[edgeweight] getDistances(bool_t moveOut) except +
+		vector[edgeweight] getDistances() except +
 		edgeweight distance(node t) except +
 		vector[node] getPredecessors(node t) except +
 		vector[node] getPath(node t, bool_t forward) except +
@@ -1356,8 +1357,9 @@ cdef class SSSP(Algorithm):
 		if type(self) == SSSP:
 			raise RuntimeError("Error, you may not use SSSP directly, use a sub-class instead")
 
-	def getDistances(self, moveOut=True):
+	def getDistances(self, moveOut):
 		"""
+		DEPRECATED
 		Returns a vector of weighted distances from the source node, i.e. the
  	 	length of the shortest path from the source node to any other node.
 
@@ -1367,6 +1369,18 @@ cdef class SSSP(Algorithm):
  	 		The weighted distances from the source node to any other node in the graph.
 		"""
 		return (<_SSSP*>(self._this)).getDistances(moveOut)
+
+	def getDistances(self):
+		"""
+		Returns a vector of weighted distances from the source node, i.e. the
+		length of the shortest path from the source node to any other node.
+
+		Returns
+		-------
+		vector
+		The weighted distances from the source node to any other node in the graph.
+		"""
+		return (<_SSSP*>(self._this)).getDistances()
 
 	def distance(self, t):
 		return (<_SSSP*>(self._this)).distance(t)

--- a/networkit/cpp/centrality/EstimateBetweenness.cpp
+++ b/networkit/cpp/centrality/EstimateBetweenness.cpp
@@ -56,7 +56,7 @@ void EstimateBetweenness::run() {
 
 
 		// create stack of nodes in non-decreasing order of distance
-		std::vector<node> stack = sssp->getNodesSortedByDistance(true);
+		auto stack = sssp->getNodesSortedByDistance();
 
 		// compute dependencies and add the contributions to the centrality score
 		std::vector<double> dependency(G.upperNodeIdBound(), 0.0);

--- a/networkit/cpp/distance/AffectedNodes.cpp
+++ b/networkit/cpp/distance/AffectedNodes.cpp
@@ -260,11 +260,11 @@ void AffectedNodes::removedEdge() {
 
     BFS bfsU(G, u);
     bfsU.run();
-    std::vector<edgeweight> distancesU = bfsU.getDistances(true);
+    auto distancesU = bfsU.getDistances();
 
     BFS bfsV(G, v);
     bfsV.run();
-    std::vector<edgeweight> distancesV = bfsV.getDistances(true);
+    auto distancesV = bfsV.getDistances();
 
     // Run a second BFS from u and v but abort if the distance to the node has
     // not decreased
@@ -293,7 +293,7 @@ void AffectedNodes::removedEdge() {
 
     ReverseBFS bfsV(G, v);
     bfsV.run();
-    std::vector<edgeweight> distancesV = bfsV.getDistances(true);
+    auto distancesV = bfsV.getDistances();
 
     // G.addEdge(u, v);
 

--- a/networkit/cpp/distance/SSSP.cpp
+++ b/networkit/cpp/distance/SSSP.cpp
@@ -17,7 +17,11 @@ SSSP::SSSP(const Graph &G, node source, bool storePaths,
       storeNodesSortedByDistance(storeNodesSortedByDistance) {}
 
 std::vector<edgeweight> SSSP::getDistances(bool moveOut) {
-    return (moveOut) ? std::move(distances) : distances;
+    return moveOut ? std::move(distances) : distances;
+}
+
+const std::vector<edgeweight> &SSSP::getDistances() {
+    return distances;
 }
 
 std::vector<node> SSSP::getPath(node t, bool forward) const {
@@ -121,6 +125,18 @@ std::vector<node> SSSP::getNodesSortedByDistance(bool moveOut) {
         return tmp;
     }
 
+    return nodesSortedByDistance;
+}
+
+const std::vector<node> &SSSP::getNodesSortedByDistance() const {
+    if (!storeNodesSortedByDistance) {
+        throw std::runtime_error(
+            "Nodes sorted by distance have not been stored. Set "
+            "storeNodesSortedByDistance in the constructor to true to enable "
+            "this behaviour.");
+    }
+
+    assert(!nodesSortedByDistance.empty());
     return nodesSortedByDistance;
 }
 


### PR DESCRIPTION
The `getDistances()` method of `SSSP` allows the distances vector to be moved out without a clear reason apart from avoiding to copy the vector. This can be done more safely by returning a const ref. The only class using this feature is `AffectedNodes`, which just reads the data.