### PR TITLE
Removed useless virtual methods, and misleading docstring

### DIFF
--- a/include/networkit/distance/BFS.hpp
+++ b/include/networkit/distance/BFS.hpp
@@ -39,11 +39,8 @@ class BFS : public SSSP {
 
     /**
      * Breadth-first search from @a source.
-     * @return Vector of unweighted distances from node @a source, i.e. the
-     * length (number of edges) of the shortest path from @a source to any other
-     * node.
      */
-    virtual void run();
+    void run() override;
 };
 } /* namespace NetworKit */
 #endif /* BFS_H_ */

--- a/include/networkit/distance/BFS.hpp
+++ b/include/networkit/distance/BFS.hpp
@@ -8,7 +8,6 @@
 #ifndef BFS_H_
 #define BFS_H_
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/distance/SSSP.hpp>
 
 namespace NetworKit {
@@ -18,11 +17,9 @@ namespace NetworKit {
  * The BFS class is used to do a breadth-first search on a Graph from a given
  * source node.
  */
-class BFS : public SSSP {
+class BFS final : public SSSP {
 
-    friend class DynBFS;
-
-  public:
+public:
     /**
      * Constructs the BFS class for @a G and source node @a source.
      *

--- a/include/networkit/distance/Dijkstra.hpp
+++ b/include/networkit/distance/Dijkstra.hpp
@@ -43,7 +43,7 @@ class Dijkstra : public SSSP {
      * Performs the Dijkstra SSSP algorithm on the graph given in the
      * constructor.
      */
-    virtual void run();
+    void run() override;
 
   private:
     struct Compare {

--- a/include/networkit/distance/Dijkstra.hpp
+++ b/include/networkit/distance/Dijkstra.hpp
@@ -10,7 +10,6 @@
 
 #include <tlx/container/d_ary_addressable_int_heap.hpp>
 
-#include <networkit/graph/Graph.hpp>
 #include <networkit/distance/SSSP.hpp>
 
 namespace NetworKit {
@@ -19,12 +18,9 @@ namespace NetworKit {
  * @ingroup distance
  * Dijkstra's SSSP algorithm.
  */
-class Dijkstra : public SSSP {
+class Dijkstra final : public SSSP {
 
-    friend class DynDijkstra;
-    friend class DynDijkstra2;
-
-  public:
+public:
     /**
      * Creates the Dijkstra class for @a G and the source node @a source.
      *
@@ -45,14 +41,14 @@ class Dijkstra : public SSSP {
      */
     void run() override;
 
-  private:
+private:
     struct Compare {
-      public:
+    public:
         Compare(const std::vector<double> &dist_) : dist(dist_) {}
 
         bool operator()(node x, node y) const { return dist[x] < dist[y]; }
 
-      private:
+    private:
         const std::vector<double> &dist;
     };
 

--- a/include/networkit/distance/DynBFS.hpp
+++ b/include/networkit/distance/DynBFS.hpp
@@ -17,7 +17,7 @@ namespace NetworKit {
  * @ingroup distance
  * Dynamic breadth-first search.
  */
-class DynBFS : public DynSSSP {
+class DynBFS final : public DynSSSP {
 
 public:
 

--- a/include/networkit/distance/DynDijkstra.hpp
+++ b/include/networkit/distance/DynDijkstra.hpp
@@ -16,7 +16,7 @@ namespace NetworKit {
  * @ingroup distance
  * Dynamic Dijkstra.
  */
-class DynDijkstra : public DynSSSP {
+class DynDijkstra final : public DynSSSP {
 
 public:
 

--- a/include/networkit/distance/SSSP.hpp
+++ b/include/networkit/distance/SSSP.hpp
@@ -22,7 +22,7 @@ namespace NetworKit {
  */
 class SSSP : public Algorithm {
 
-  public:
+public:
     /**
      * Creates the SSSP class for @a G and source @a s.
      *
@@ -149,7 +149,7 @@ class SSSP : public Algorithm {
         return sumDist;
     }
 
-  protected:
+protected:
     const Graph &G;
     node source;
     node target;

--- a/networkit/cpp/distance/BFS.cpp
+++ b/networkit/cpp/distance/BFS.cpp
@@ -2,7 +2,8 @@
  * BFS.cpp
  *
  *  Created on: Jul 23, 2013
- *      Author: Henning */
+ *      Author: Henning
+ */
 
 #include <queue>
 

--- a/networkit/cpp/distance/DynBFS.cpp
+++ b/networkit/cpp/distance/DynBFS.cpp
@@ -20,10 +20,13 @@ color(G.upperNodeIdBound(), WHITE) {
 void DynBFS::run() {
 	BFS bfs(G, source, true);
 	bfs.run();
-	distances = bfs.distances;
-	npaths = bfs.npaths;
-	if (storePreds)
-		previous = bfs.previous;
+	distances = bfs.getDistances();
+	npaths.reserve(G.upperNodeIdBound());
+	G.forNodes([&](node u) {npaths.push_back(bfs.numberOfPaths(u)); });
+	if (storePreds) {
+		previous.resize(G.upperNodeIdBound());
+		G.forNodes([&](node u) { previous[u] = bfs.getPredecessors(u); });
+	}
 	maxDistance = 0;
 	G.forNodes([&](node v){
 		if (distances[v] > maxDistance)

--- a/networkit/cpp/distance/DynDijkstra.cpp
+++ b/networkit/cpp/distance/DynDijkstra.cpp
@@ -5,28 +5,29 @@
  *      Author: ebergamini
  */
 
+#include <queue>
+
 #include <networkit/distance/Dijkstra.hpp>
 #include <networkit/distance/DynDijkstra.hpp>
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/auxiliary/PrioQueue.hpp>
 #include <networkit/auxiliary/NumericTools.hpp>
-#include <queue>
 
 
 namespace NetworKit {
 
 DynDijkstra::DynDijkstra(const Graph& G, node source, bool storePredecessors) : DynSSSP(G, source, storePredecessors),
-color(G.upperNodeIdBound(), WHITE) {
-
-}
+color(G.upperNodeIdBound(), WHITE) {}
 
 void DynDijkstra::run() {
 	Dijkstra dij(G, source, true);
 	dij.run();
-	distances = dij.distances;
-	npaths = dij.npaths;
+	distances = dij.getDistances();
+	npaths.reserve(G.upperNodeIdBound());
+	G.forNodes([&](node u) { npaths.push_back(dij.numberOfPaths(u)); });
 	if (storePreds) {
-		previous = dij.previous;
+		previous.resize(G.upperNodeIdBound());
+		G.forNodes([&](node u) {previous[u] = dij.getPredecessors(u); });
 	}
 }
 


### PR DESCRIPTION
Removed `virtual` from `run()` methods, removed `@return` docstring from a method returning `void`.