### PR TITLE
Move extractLargestConnectedComponent to component

### DIFF
--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -68,6 +68,14 @@ public:
      */
     std::vector<std::vector<node> > getComponents() const;
 
+    /**
+     * Constructs a new graph that contains only the nodes inside the largest
+     * connected component.
+     * @param G            The input graph.
+     * @param compactGraph If true, the node ids of the output graph will be compacted
+     * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
+     */
+    static Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
 
 private:
 	const Graph& G;

--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -8,10 +8,13 @@
 #ifndef CONNECTEDCOMPONENTS_H_
 #define CONNECTEDCOMPONENTS_H_
 
+#include <cassert>
+#include <map>
+#include <vector>
+
 #include <networkit/graph/Graph.hpp>
 #include <networkit/structures/Partition.hpp>
 #include <networkit/base/Algorithm.hpp>
-#include <unordered_set>
 
 namespace NetworKit {
 

--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -34,14 +34,14 @@ public:
 	/**
 	 * This method determines the connected components for the graph given in the constructor.
 	 */
-	void run();
+	void run() override;
 
 	/**
 	 * Get the number of connected components.
 	 *
 	 * @return The number of connected components.
 	 */
-	count numberOfComponents();
+	count numberOfComponents() const;
 
 	/**
 	 * Get the the component in which node @a u is situated.
@@ -56,17 +56,17 @@ public:
 	 *
 	 * @return A partition representing the found components.
 	 */
-	Partition getPartition();
+	Partition getPartition() const;
 
     /**
      *Return the map from component to size
      */
-    std::map<index, count> getComponentSizes();
+    std::map<index, count> getComponentSizes() const;
 
     /**
      * @return Vector of components, each stored as (unordered) set of nodes.
      */
-    std::vector<std::vector<node> > getComponents();
+    std::vector<std::vector<node> > getComponents() const;
 
 
 private:
@@ -81,7 +81,7 @@ inline count ConnectedComponents::componentOfNode(node u) const {
 	return component[u];
 }
 
-inline count ConnectedComponents::numberOfComponents() {
+inline count ConnectedComponents::numberOfComponents() const {
 	assureFinished();
 	return this->numComponents;
 }

--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -103,15 +103,6 @@ Graph getRemappedGraph(const Graph& graph, count numNodes, UnaryIdMapper&& oldId
         std::forward<UnaryIdMapper>(oldIdToNew), [](node) { return false; }, preallocate);
 }
 
-/**
- * Constructs a new graph that contains only the nodes inside the largest
- * connected component.
- * @param G            The input graph.
- * @param compactGraph If true, the node ids of the output graph will be compacted
- * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
- */
-Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
-
 
 }	// namespace GraphTools
 }	// namespace NetworKit

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -4522,7 +4522,6 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph getCompactedGraph(_Graph G, unordered_map[node,node]) nogil except +
 	unordered_map[node,node] getContinuousNodeIds(_Graph G) nogil except +
 	unordered_map[node,node] getRandomContinuousNodeIds(_Graph G) nogil except +
-	_Graph extractLargestConnectedComponent(_Graph G, bool_t) nogil except +
 
 cdef class GraphTools:
 	@staticmethod
@@ -4560,34 +4559,6 @@ cdef class GraphTools:
 		for elem in cResult:
 			result[elem.first] = elem.second
 		return result
-
-	@staticmethod
-	def extractLargestConnectedComponent(Graph graph, bool_t compactGraph = False):
-		"""
-			Constructs a new graph that contains only the nodes inside the
-			largest connected component.
-
-			Parameters
-			----------
-			graph: networkit.Graph
-				The input graph
-			compactGraph: bool
-				if true, the node ids of the output graph will be compacted
-				(i.e., re-numbered from 0 to n-1). If false, the node ids
-				will not be changed.
-
-			Returns
-			-------
-			networkit.Graph
-				A graph that contains only the nodes inside the largest
-				connected component.
-
-
-			Note
-			----
-			Available for undirected graphs only.
-		"""
-		return Graph().setThis(extractLargestConnectedComponent(graph._this, compactGraph))
 
 
 cdef extern from "<networkit/community/PartitionIntersection.hpp>":
@@ -5590,7 +5561,8 @@ cdef extern from "<networkit/components/ConnectedComponents.hpp>":
 		_Partition getPartition() except +
 		map[index, count] getComponentSizes() except +
 		vector[vector[node]] getComponents() except +
-
+		@staticmethod
+		_Graph extractLargestConnectedComponent(_Graph G, bool_t) nogil except +
 
 cdef class ConnectedComponents(Algorithm):
 	""" Determines the connected components and associated values for an undirected graph.
@@ -5650,6 +5622,34 @@ cdef class ConnectedComponents(Algorithm):
 			The connected components.
 		"""
 		return (<_ConnectedComponents*>(self._this)).getComponents()
+
+	@staticmethod
+	def extractLargestConnectedComponent(Graph graph, bool_t compactGraph = False):
+		"""
+			Constructs a new graph that contains only the nodes inside the
+			largest connected component.
+
+			Parameters
+			----------
+			graph: networkit.Graph
+				The input graph
+			compactGraph: bool
+				if true, the node ids of the output graph will be compacted
+				(i.e., re-numbered from 0 to n-1). If false, the node ids
+				will not be changed.
+
+			Returns
+			-------
+			networkit.Graph
+				A graph that contains only the nodes inside the largest
+				connected component.
+
+
+			Note
+			----
+			Available for undirected graphs only.
+		"""
+		return Graph().setThis(_ConnectedComponents.extractLargestConnectedComponent(graph._this, compactGraph))
 
 cdef extern from "<networkit/components/ParallelConnectedComponents.hpp>":
 

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -55,13 +55,13 @@ void ConnectedComponents::run() {
 }
 
 
-Partition ConnectedComponents::getPartition() {
+Partition ConnectedComponents::getPartition() const {
 	assureFinished();
 	return this->component;
 }
 
 
-std::vector<std::vector<node> > ConnectedComponents::getComponents() {
+std::vector<std::vector<node> > ConnectedComponents::getComponents() const {
 	assureFinished();
 
 	// transform partition into vector of unordered_set
@@ -76,7 +76,7 @@ std::vector<std::vector<node> > ConnectedComponents::getComponents() {
 
 
 
-std::map<index, count> ConnectedComponents::getComponentSizes() {
+std::map<index, count> ConnectedComponents::getComponentSizes() const {
 	assureFinished();
 	return this->component.subsetSizeMap();
 }

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -6,10 +6,12 @@
  */
 
 #include <set>
+#include <unordered_map>
 
-#include <networkit/components/ConnectedComponents.hpp>
-#include <networkit/structures/Partition.hpp>
 #include <networkit/auxiliary/Log.hpp>
+#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/structures/Partition.hpp>
 
 namespace NetworKit {
 
@@ -79,6 +81,49 @@ std::vector<std::vector<node> > ConnectedComponents::getComponents() const {
 std::map<index, count> ConnectedComponents::getComponentSizes() const {
 	assureFinished();
 	return this->component.subsetSizeMap();
+}
+
+Graph ConnectedComponents::extractLargestConnectedComponent(const Graph &G, bool compactGraph) {
+    if (!G.numberOfNodes())
+        return G;
+
+    ConnectedComponents cc(G);
+    cc.run();
+
+    auto compSizes = cc.getComponentSizes();
+    if (compSizes.size() == 1)
+        return G;
+
+    auto largestCC = std::max_element(
+        compSizes.begin(), compSizes.end(),
+        [](const std::pair<index, count> &x, const std::pair<index, count> &y) {
+            return x.second < y.second;
+        });
+
+    std::unordered_map<node, node> continuousNodeIds;
+    index nextId = 0;
+    G.forNodes([&](node u) {
+        if (cc.componentOfNode(u) == largestCC->first)
+            continuousNodeIds[u] = nextId++;
+    });
+
+    if (compactGraph) {
+        return GraphTools::getRemappedGraph(
+            G, largestCC->second,
+            [&](node u) { return continuousNodeIds[u]; },
+            [&](node u) { return cc.componentOfNode(u) != largestCC->first; });
+
+    } else {
+        Graph S(G);
+        auto components = cc.getComponents();
+        for (count i = 0; i < components.size(); ++i) {
+            if (i != largestCC->first) {
+                for (node u : components[i])
+                    S.removeNode(u);
+            }
+        }
+        return S;
+    }
 }
 
 }

--- a/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
+++ b/networkit/cpp/components/test/ConnectedComponentsGTest.cpp
@@ -514,4 +514,27 @@ TEST_F(ConnectedComponentsGTest, testDynWeaklyConnectedComponents) {
     EXPECT_EQ(wc.numberOfComponents(), dw.numberOfComponents());
 }
 
+TEST_F(ConnectedComponentsGTest, testExtractLargestConnectedComponent) {
+    Graph G(8);
+
+    G.addEdge(0, 1);
+    G.addEdge(2, 1);
+    G.addEdge(3, 1);
+    G.addEdge(4, 1);
+
+    G.addEdge(5, 6);
+    Graph G1(G);
+
+    G = ConnectedComponents::extractLargestConnectedComponent(G, true);
+    EXPECT_EQ(G.numberOfNodes(), 5);
+    EXPECT_EQ(G.upperNodeIdBound(), 5);
+    EXPECT_EQ(G.numberOfEdges(), 4);
+
+    G1 = ConnectedComponents::extractLargestConnectedComponent(G1, false);
+    EXPECT_EQ(G1.numberOfNodes(), 5);
+    EXPECT_EQ(G1.upperNodeIdBound(), 8);
+    EXPECT_EQ(G1.numberOfEdges(), 4);
+}
+
+
 } /* namespace NetworKit */

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -1,8 +1,7 @@
 #include <algorithm>
-#include <random>
 #include <unordered_map>
 
-#include <networkit/components/ConnectedComponents.hpp>
+#include <networkit/auxiliary/Random.hpp>
 #include <networkit/graph/GraphTools.hpp>
 #include <networkit/graph/Graph.hpp>
 
@@ -73,48 +72,6 @@ Graph restoreGraph(const std::vector<node>& invertedIdMap, const Graph& G) {
 		}
 	});
 	return Goriginal;
-}
-
-Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph) {
-	if (!G.numberOfNodes())
-		return G;
-
-	ConnectedComponents cc(G);
-	cc.run();
-
-	auto compSizes = cc.getComponentSizes();
-	if (compSizes.size() == 1)
-			return G;
-
-	auto largestCC = std::max_element(
-		compSizes.begin(), compSizes.end(),
-		[](const std::pair<index, count> &x, const std::pair<index, count> &y) {
-			return x.second < y.second;
-		});
-
-	std::unordered_map<node, node> continuousNodeIds;
-	index nextId = 0;
-	G.forNodes([&](node u) {
-		if (cc.componentOfNode(u) == largestCC->first)
-			continuousNodeIds[u] = nextId++;
-	});
-
-	if (compactGraph) {
-		Graph S = getRemappedGraph(G, largestCC->second,
-			[&](node u) { return continuousNodeIds[u]; },
-			[&](node u) { return cc.componentOfNode(u) != largestCC->first; });
-		return S;
-	} else {
-		Graph S(G);
-		auto components = cc.getComponents();
-		for (count i = 0; i < components.size(); ++i) {
-			if (i != largestCC->first) {
-				for (node u : components[i])
-					S.removeNode(u);
-			}
-		}
-		return S;
-	}
 }
 
 } // namespace GraphTools

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -303,26 +303,4 @@ TEST_F(GraphToolsGTest, testGetRemappedGraphWithDelete) {
 	}
 }
 
-TEST_F(GraphToolsGTest, testExtractLargestConnectedComponent) {
-	Graph G(8);
-
-	G.addEdge(0, 1);
-	G.addEdge(2, 1);
-	G.addEdge(3, 1);
-	G.addEdge(4, 1);
-
-	G.addEdge(5, 6);
-	Graph G1(G);
-
-	G = GraphTools::extractLargestConnectedComponent(G, true);
-	EXPECT_EQ(G.numberOfNodes(), 5);
-	EXPECT_EQ(G.upperNodeIdBound(), 5);
-	EXPECT_EQ(G.numberOfEdges(), 4);
-
-	G1 = GraphTools::extractLargestConnectedComponent(G1, false);
-	EXPECT_EQ(G1.numberOfNodes(), 5);
-	EXPECT_EQ(G1.upperNodeIdBound(), 8);
-	EXPECT_EQ(G1.numberOfEdges(), 4);
-}
-
 } // namespace NetworKit

--- a/networkit/test/test_algorithms.py
+++ b/networkit/test/test_algorithms.py
@@ -347,6 +347,21 @@ class Test_SelfLoops(unittest.TestCase):
 		CC.getPartition()
 		CC.numberOfComponents()
 
+	def test_extractLargestConnectedComponent(self):
+		G = Graph(10)
+		for i in range(3):
+			G.addEdge(i, i+1)
+
+		for i in range(4, 9):
+			G.addEdge(i, i+1)
+
+		G1 = components.ConnectedComponents.extractLargestConnectedComponent(G, True)
+		self.assertEqual(G1.numberOfNodes(), 6)
+		self.assertEqual(G1.numberOfEdges(), 5)
+
+		G2 = components.ConnectedComponents.extractLargestConnectedComponent(G, False)
+		for i in range(G.numberOfNodes()):
+			self.assertEqual(G2.hasNode(i), (4 <= i <= 9))
 
 	def test_distance_Diameter(self):
 		D = distance.Diameter(self.LL, distance.DiameterAlgo.EstimatedRange, error = 0.1)


### PR DESCRIPTION
Fixes issue #340 by moving `extractLargestComponent` from `GraphTools` to `ConnectedComponent`. As a bonus, there are now also Python Test for the interface and const methods in `ConnectedComponent`.

CI Homebrew issue still causing one test to fail.